### PR TITLE
Add Travis CI using ROS-Industrial CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required
+language: generic
+env:
+  matrix:
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" PRERELEASE=true
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" PRERELEASE=true
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@
 sudo: required
 language: generic
 env:
-  global:
-    - NOT_TEST_INSTALL=true NOT_TEST_BUILD=true
   matrix:
     - ROS_DISTRO="kinetic"
-    - ROS_DISTRO="kinetic" PRERELEASE=true
+    - ROS_DISTRO="kinetic" PRERELEASE=true NOT_TEST_INSTALL=true NOT_TEST_BUILD=true
     - ROS_DISTRO="melodic"
-    - ROS_DISTRO="melodic" PRERELEASE=true
+    - ROS_DISTRO="melodic" PRERELEASE=true NOT_TEST_INSTALL=true NOT_TEST_BUILD=true
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 sudo: required
 language: generic
 env:
+  global:
+    - NOT_TEST_INSTALL=true NOT_TEST_BUILD=true
   matrix:
     - ROS_DISTRO="kinetic"
     - ROS_DISTRO="kinetic" PRERELEASE=true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ AprilTags are a visual fiducial system popular in robotics research. This reposi
 
 You can find tag images for the pre-generated layouts [here](https://github.com/AprilRobotics/apriltag-imgs).
 
+[![Build Status](https://travis-ci.org/AprilRobotics/apriltag.svg?branch=master)](https://travis-ci.org/AprilRobotics/apriltag)
+
 Install
 =======
 


### PR DESCRIPTION
This PR adds continuous integration using Travis which will run build (using catkin which internally uses the CMake build) at every push/PR. This PR uses ROS-Industrial CI which also tests whether the package can be released (by running the pre-release tests). 

Example output from my fork: https://travis-ci.com/wxmerkt/apriltag/builds/108943931

This will require activating Travis for the repository/organisation manually after this PR has been merged.