### PR TITLE
Added a cast from int to unsigned int in common/matd.h

### DIFF
--- a/common/matd.h
+++ b/common/matd.h
@@ -271,7 +271,7 @@ static inline int matd_is_vector(const matd_t *a)
 static inline int matd_is_vector_len(const matd_t *a, int len)
 {
     assert(a != NULL);
-    return (a->ncols == 1 && a->nrows == len) || (a->ncols == len && a->nrows == 1);
+    return (a->ncols == 1 && a->nrows == (unsigned int)len) || (a->ncols == (unsigned int)len && a->nrows == 1);
 }
 
 /**


### PR DESCRIPTION
This prevents compilation errors when including apriltag headers into external libraries which have -Werror and -Wall enabled.