### PR TITLE
Set version to 3.1 and add myself as maintainer for bloom release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
     target_link_libraries(${PROJECT_NAME} Threads::Threads m)
 endif()
 
-set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION 3.0.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION 3.1.0)
 
 include(GNUInstallDirs)
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/package.xml
+++ b/package.xml
@@ -2,10 +2,11 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>apriltag</name>
-  <version>0.10.0</version>
+  <version>3.1.0</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
 
   <author email="ebolson@umich.edu">Edwin Olson</author>
   <author email="mkrogius@umich.edu">Max Krogius</author>


### PR DESCRIPTION
Now that the ROS wrapper update is merged, I am intending to progress with releasing the library via bloom in order to release `apriltag_ros`. 

To receive the status emails, I have added myself as a maintainer. @mkrogius, if you go ahead with merging this PR, can you please tag the post-merge master to `3.1.0`?

Related to #16