### PR TITLE
Fix warnings detected with -Wsizeof-pointer-memaccess and -Wshadow

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -1062,9 +1062,9 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
     // adjust centers of pixels so that they correspond to the
     // original full-resolution image.
     if (td->quad_decimate > 1) {
-        for (int i = 0; i < zarray_size(quads); i++) {
+        for (int idx = 0; idx < zarray_size(quads); idx++) {
             struct quad *q;
-            zarray_get_volatile(quads, i, &q);
+            zarray_get_volatile(quads, idx, &q);
 
             for (int i = 0; i < 4; i++) {
                 if (td->quad_decimate == 1.5) {
@@ -1264,9 +1264,9 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
 
         image_u8_destroy(darker);
 
-        for (int i = 0; i < zarray_size(detections); i++) {
+        for (int idx = 0; idx < zarray_size(detections); idx++) {
             apriltag_detection_t *det;
-            zarray_get(detections, i, &det);
+            zarray_get(detections, idx, &det);
 
             float rgb[3];
             int bias = 100;
@@ -1303,9 +1303,9 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
 
         image_u8_destroy(darker);
 
-        for (int i = 0; i < zarray_size(detections); i++) {
+        for (int idx = 0; idx < zarray_size(detections); idx++) {
             apriltag_detection_t *det;
-            zarray_get(detections, i, &det);
+            zarray_get(detections, idx, &det);
 
             float rgb[3];
             int bias = 100;
@@ -1345,9 +1345,9 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
 
         image_u8_destroy(darker);
 
-        for (int i = 0; i < zarray_size(quads); i++) {
+        for (int idx = 0; idx < zarray_size(quads); idx++) {
             struct quad *q;
-            zarray_get_volatile(quads, i, &q);
+            zarray_get_volatile(quads, idx, &q);
 
             float rgb[3];
             int bias = 100;

--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -69,7 +69,7 @@ double orthogonal_iteration(matd_t** v, matd_t** p, matd_t** t, matd_t** R, int 
 
     double prev_error = HUGE_VAL;
     // Iterate.
-    for (int i = 0; i < n_steps; i++) {
+    for (int iter = 0; iter < n_steps; iter++) {
         // Calculate translation.
         matd_t *M2 = matd_create(3, 1);
         for (int j = 0; j < n_points; j++) {
@@ -409,10 +409,10 @@ matd_t* fix_pose_ambiguities(matd_t** v, matd_t** p, matd_t* t, matd_t* R, int n
         // Check extrema is a minima.
         if (a2 - 2*a0 + (3*a3 - 6*a1)*t1 + (6*a4 - 8*a2 + 10*a0)*t2 + (-8*a3 + 6*a1)*t3 + (-6*a4 + 3*a2)*t4 + a3*t5 >= 0) {
             // And that it corresponds to an angle different than the known minimum.
-            double t = 2*atan(roots[i]);
+            double t_cur = 2*atan(roots[i]);
             // We only care about finding a second local minima which is qualitatively
             // different than the first.
-            if (fabs(t - t_initial) > 0.1) {
+            if (fabs(t_cur - t_initial) > 0.1) {
                 minima[n_minima++] = roots[i];
             }
         }
@@ -421,13 +421,13 @@ matd_t* fix_pose_ambiguities(matd_t** v, matd_t** p, matd_t* t, matd_t* R, int n
     // 5. Get poses for minima.
     matd_t* ret = NULL;
     if (n_minima == 1) {
-        double t = minima[0];
+        double t_cur = minima[0];
         matd_t* R_beta = matd_copy(M2);
-        matd_scale_inplace(R_beta, t);
+        matd_scale_inplace(R_beta, t_cur);
         matd_add_inplace(R_beta, M1);
-        matd_scale_inplace(R_beta, t);
+        matd_scale_inplace(R_beta, t_cur);
         matd_add_inplace(R_beta, I3);
-        matd_scale_inplace(R_beta, 1/(1 + t*t));
+        matd_scale_inplace(R_beta, 1/(1 + t_cur*t_cur));
         ret = matd_op("M'MMM'", R_t, R_gamma, R_beta, R_z);
         matd_destroy(R_beta);
     } else if (n_minima > 1)  {

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1714,10 +1714,10 @@ zarray_t* gradient_clusters(apriltag_detector_t *td, image_u8_t* threshim, int w
     clusters = zarray_create(sizeof(zarray_t*));
     zarray_ensure_capacity(clusters, zarray_size(clusters_list[0]));
     for (int i = 0; i < zarray_size(clusters_list[0]); i++) {
-        struct cluster_hash* h;
-        zarray_get(clusters_list[0], i, &h);
-        zarray_add(clusters, &h->data);
-        free(h);
+        struct cluster_hash* hash;
+        zarray_get(clusters_list[0], i, &hash);
+        zarray_add(clusters, &hash->data);
+        free(hash);
     }
     zarray_destroy(clusters_list[0]);
     free(clusters_list);
@@ -1894,9 +1894,9 @@ zarray_t *apriltag_quad_thresh(apriltag_detector_t *td, image_u8_t *im)
 
         image_u8_destroy(im2);
 
-        for (int i = 0; i < zarray_size(quads); i++) {
+        for (int idx = 0; idx < zarray_size(quads); idx++) {
             struct quad *q;
-            zarray_get_volatile(quads, i, &q);
+            zarray_get_volatile(quads, idx, &q);
 
             float rgb[3];
             int bias = 100;

--- a/common/pjpeg.c
+++ b/common/pjpeg.c
@@ -549,16 +549,16 @@ static int pjpeg_decode_buffer(struct pjpeg_decode_state *pjd)
                                 printf("RST SYNC\n");
                             }
 
-                            int32_t marker = bd_consume_bits(&bd, 8);
+                            int32_t marker_32 = bd_consume_bits(&bd, 8);
 
-//                            printf("%04x: RESET? %02x\n", *bd.inpos,  marker);
-                            if (marker != (0xd0 + pjd->reset_next))
+//                            printf("%04x: RESET? %02x\n", *bd.inpos,  marker_32);
+                            if (marker_32 != (0xd0 + pjd->reset_next))
                                 return PJPEG_ERR_RESET;
 
                             pjd->reset_count = 0;
                             pjd->reset_next = (pjd->reset_next + 1) & 0x7;
 
-                            memset(dcpred, 0, sizeof(dcpred));
+                            memset(dcpred, 0, sizeof(*dcpred));
                         }
 
                         for (int nsidx = 0; nsidx < ns; nsidx++) {

--- a/common/string_util.c
+++ b/common/string_util.c
@@ -202,10 +202,10 @@ zarray_t *str_split_spaces(const char *str)
 	pos++;
       size_t off1 = pos;
 
-      size_t len = off1 - off0;
-      char *tok = malloc(len + 1);
-      memcpy(tok, &str[off0], len);
-      tok[len] = 0;
+      size_t len_off = off1 - off0;
+      char *tok = malloc(len_off + 1);
+      memcpy(tok, &str[off0], len_off);
+      tok[len_off] = 0;
       zarray_add(parts, &tok);
     }
   }

--- a/common/zhash.c
+++ b/common/zhash.c
@@ -179,11 +179,11 @@ int zhash_put(zhash_t *zh, const void *key, const void *value, void *oldkey, voi
                                                  zh->hash, zh->equals,
                                                  zh->size);
 
-        for (int entry_idx = 0; entry_idx < zh->nentries; entry_idx++) {
+        for (int idx = 0; idx < zh->nentries; idx++) {
 
-            if (zh->entries[entry_idx * zh->entrysz]) {
-                void *this_key = &zh->entries[entry_idx * zh->entrysz + 1];
-                void *this_value = &zh->entries[entry_idx * zh->entrysz + 1 + zh->keysz];
+            if (zh->entries[idx * zh->entrysz]) {
+                void *this_key = &zh->entries[idx * zh->entrysz + 1];
+                void *this_value = &zh->entries[idx * zh->entrysz + 1 + zh->keysz];
                 if (zhash_put(newhash, this_key, this_value, NULL, NULL))
                     assert(0); // shouldn't already be present.
             }


### PR DESCRIPTION
Example:

```
warning: declaration of ‘entry_idx’ shadows a previous local [-Wshadow]
         for (int entry_idx = 0; entry_idx < zh->nentries; entry_idx++) {
                  ^

```
and

```
warning: argument to ‘sizeof’ in ‘memset’ call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
                             memset(dcpred, 0, sizeof(dcpred));
                                                     ^

```