### PR TITLE
Add support for using Python 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,15 +61,14 @@ STRING(REGEX REPLACE "^prefix=" "prefix=${CMAKE_INSTALL_PREFIX}" PKGC_CONF "${PK
 FILE(WRITE ${PROJECT_BINARY_DIR}/apriltag.pc ${PKGC_CONF})
 install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "lib/pkgconfig/")
 
-
 # Python wrapper
-SET(Python_ADDITIONAL_VERSIONS 3)
+SET(PREFERRED_PYTHON_VERSION 3 CACHE STRING "Preferred Python version 2/3")
+SET(Python_ADDITIONAL_VERSIONS ${PREFERRED_PYTHON_VERSION} 3 2)
+find_package(PythonInterp)
 find_package(PythonLibs)
-execute_process(COMMAND which python3 OUTPUT_QUIET RESULT_VARIABLE Python3_NOT_FOUND)
-execute_process(COMMAND python3 -c "import numpy" RESULT_VARIABLE Numpy_NOT_FOUND)
-if (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND)
-# TODO deal with both python2/3
-execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/python_build_flags.py OUTPUT_VARIABLE PY_OUT)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import numpy" RESULT_VARIABLE Numpy_NOT_FOUND)
+if (NOT PYTHONINTERP_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python_build_flags.py OUTPUT_VARIABLE PY_OUT)
 set(PY_VARS CFLAGS LDFLAGS LINKER EXT_SUFFIX)
 cmake_parse_arguments(PY "" "${PY_VARS}" "" ${PY_OUT})
 separate_arguments(PY_CFLAGS)
@@ -91,11 +90,10 @@ add_custom_command(OUTPUT apriltag${PY_EXT_SUFFIX}
 add_custom_target(apriltag_python ALL
     DEPENDS apriltag${PY_EXT_SUFFIX})
 
-execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -m site --user-site OUTPUT_VARIABLE PY_DEST)
 string(STRIP ${PY_DEST} PY_DEST)
 install(CODE "execute_process(COMMAND cp ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} ${PY_DEST})")
-endif (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND)
-
+endif (NOT PYTHONINTERP_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND)
 
 # Examples
 # apriltag_demo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FILE(WRITE ${PROJECT_BINARY_DIR}/apriltag.pc ${PKGC_CONF})
 install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "lib/pkgconfig/")
 
 # Python wrapper
-SET(PREFERRED_PYTHON_VERSION 3 CACHE STRING "Preferred Python version 2/3")
+SET(PREFERRED_PYTHON_VERSION $ENV{ROS_PYTHON_VERSION} CACHE STRING "Preferred Python version 2/3")
 SET(Python_ADDITIONAL_VERSIONS ${PREFERRED_PYTHON_VERSION} 3 2)
 find_package(PythonInterp)
 find_package(PythonLibs)

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+
   <name>apriltag</name>
   <version>3.1.1</version>
   <description>AprilTag detector library</description>
@@ -19,6 +22,7 @@
   <export>
     <build_type>cmake</build_type>
   </export>
-  <depend>python-numpy</depend>
-  <depend>python3-numpy</depend>
+
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -19,4 +19,6 @@
   <export>
     <build_type>cmake</build_type>
   </export>
+  <depend>python-numpy</depend>
+  <depend>python3-numpy</depend>
 </package>


### PR DESCRIPTION
In many scenarios (e.g. using ROS Kinetic) it might be convenient to use Python 2 instead of 3. This PR adds support for Python 2 by specifying ` -DPREFERRED_PYTHON_VERSION=2`.