### PR TITLE
use FILES rules to install python wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ add_custom_target(apriltag_python ALL
 
 execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
 string(STRIP ${PY_DEST} PY_DEST)
-install(CODE "execute_process(COMMAND cp ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} ${PY_DEST})")
+install(FILES ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} DESTINATION ${PY_DEST})
 endif (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND)
 
 


### PR DESCRIPTION
If apriltag is installed locally and `~/.local/lib/python3.6` does not exist, the installation will fail with: `cp: cannot create regular file '/home/ubuntu/.local/lib/python3.6/site-packages': No such file or directory`. 

This is caused by
https://github.com/AprilRobotics/apriltag/blob/cad1009f9fbf457e2a5393c0fb6c8a05042a0611/CMakeLists.txt#L96
since files are simply copied via the `cp` command, which does not automatically create the file structure.

This PR installs this file via https://cmake.org/cmake/help/v3.13/command/install.html#installing-files which creates the necessary file hierarchy.