### PR TITLE
Remove space-separated CMAKE_C_FLAGS in add_custom_command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/apriltag_${X}.docstring.h
 endforeach()
 
 add_custom_command(OUTPUT apriltag_pywrap.o
-    COMMAND ${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS} ${PY_CFLAGS} -I${PROJECT_BINARY_DIR} -c -o apriltag_pywrap.o ${CMAKE_SOURCE_DIR}/apriltag_pywrap.c
+    COMMAND ${CMAKE_C_COMPILER} ${PY_CFLAGS} -I${PROJECT_BINARY_DIR} -c -o apriltag_pywrap.o ${CMAKE_SOURCE_DIR}/apriltag_pywrap.c
     DEPENDS ${CMAKE_SOURCE_DIR}/apriltag_pywrap.c ${PROJECT_BINARY_DIR}/apriltag_detect.docstring.h ${PROJECT_BINARY_DIR}/apriltag_py_type.docstring.h)
 add_custom_command(OUTPUT apriltag${PY_EXT_SUFFIX}
     COMMAND ${PY_LINKER} ${PY_LDFLAGS} -Wl,-rpath=lib apriltag_pywrap.o ${LIB_APRILTAG_PATH}/libapriltag.so -o apriltag${PY_EXT_SUFFIX}


### PR DESCRIPTION
The build failed if `-DCMAKE_C_FLAGS` is set in cmake command. Here is an example command

```
"cmake" ".." "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sect
ions -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_BUILD_TYPE=Debug"
```

I dumped `make VERBOSE=1`. It shows that the space in `CMAKE_C_FLAGS` is escaped in command line. This is due to the rule of add\_custom\_command [here](https://github.com/AprilRobotics/apriltag/blob/cad1009f9fbf457e2a5393c0fb6c8a05042a0611/CMakeLists.txt#L86).

```
[ 87%] Generating apriltag_pywrap.o
/usr/bin/cc \ -ffunction-sections\ -fdata-sections\ -fPIC\ -m64 -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -march=x86-64 -mtune=generic -pipe -fno-plt -fno-semantic-interpos
ition -march=x86-64 -mtune=generic -pipe -fno-plt -march=x86-64 -mtune=generic -pipe -fno-plt -fPIC -I/usr/include/python3.8 -I/usr/lib/python3.8/site-packages/numpy/core/include -Wno-strict
-prototypes -I/home/jerry73204/data/repos/apriltag/build -c -o apriltag_pywrap.o /home/jerry73204/data/repos/apriltag/apriltag_pywrap.c
cc: error:  -ffunction-sections -fdata-sections -fPIC -m64: No such file or directory
```

It seems the `${PY_CFLAGS}` already duplicates `${CMAKE_C_FLAGS}`. The fix is done by removing `${CMAKE_C_FLAGS}` anyway.