### PR TITLE
Fix memory corruption on mem_pools in do_gradient_clusters() 

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1484,7 +1484,7 @@ zarray_t* do_gradient_clusters(image_u8_t* threshim, int ts, int y0, int y1, int
     struct uint64_zarray_entry **clustermap = calloc(nclustermap, sizeof(struct uint64_zarray_entry*));
 
     int mem_chunk_size = 2048;
-    struct uint64_zarray_entry** mem_pools = malloc(sizeof(struct uint64_zarray_entry *)*2*nclustermap/mem_chunk_size);
+    struct uint64_zarray_entry** mem_pools = malloc(sizeof(struct uint64_zarray_entry *)*(1 + 2 * nclustermap / mem_chunk_size)); // SmodeTech: avoid memory corruption when nclustermap < mem_chunk_size
     int mem_pool_idx = 0;
     int mem_pool_loc = 0;
     mem_pools[mem_pool_idx] = calloc(mem_chunk_size, sizeof(struct uint64_zarray_entry));


### PR DESCRIPTION
Hello,

I found myself in a case where `nclustermap < mem_chunk_size` resulting in `sizeof(struct uint64_zarray_entry *)*2*nclustermap/mem_chunk_size == 6`, which is not a multiple of the size of pointer!

At least the code should be:
`malloc(sizeof(struct uint64_zarray_entry *)*(2*nclustermap/mem_chunk_size));`
in order to ensure we get an integer amount of pointer.

I made the following patch, since it appears that we at least need a size of 1:
`malloc(sizeof(struct uint64_zarray_entry *)*(1 + 2 * nclustermap / mem_chunk_size));`

