### PR TITLE
Fix unnecessary escaping in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD
 # TODO deal with both python2/3
 execute_process(COMMAND python3 ${PROJECT_SOURCE_DIR}/python_build_flags.py OUTPUT_VARIABLE PY_OUT)
 set(PY_VARS CFLAGS LDFLAGS LINKER EXT_SUFFIX)
-cmake_parse_arguments(PY "" "${PY_VARS}" "" ${PY_OUT})
+cmake_parse_arguments(PY "" ${PY_VARS} "" ${PY_OUT})
 separate_arguments(PY_CFLAGS)
 separate_arguments(PY_LDFLAGS)
 


### PR DESCRIPTION
I found the `cmake && make` failed when CFLAGS contains whitespaces, such as `CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fstack-protector-strong"`. The cmake emits the command like this:

```
cc -march=x86-64\ -mtune=generic\ -O2\ -pipe\ -fstack-protector-strong\ -fno-plt ...
```

This patch fixes unnecessary whitespace escaping in CMake.

EDIT:
The command was wrong. It should be

```
export CPPFLAGS="-D_FORTIFY_SOURCE=2"
export CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fstack-protector-strong" 
cmake ../apriltag-3.1.3 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr && make VERBOSE=1
```