### PR TITLE
[cmake] install fixes and refactoring

### DIFF
--- a/CMake/apriltagConfig.cmake
+++ b/CMake/apriltagConfig.cmake
@@ -1,7 +1,0 @@
-include("${CMAKE_CURRENT_LIST_DIR}/apriltagTargets.cmake")
-
-if (NOT MSVC) 
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
-endif()
-

--- a/CMake/apriltagConfig.cmake.in
+++ b/CMake/apriltagConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+if (NOT MSVC) 
+    include(CMakeFindDependencyMacro)
+    find_dependency(Threads)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
     target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads m)
 endif()
 
-set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION 3.1.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION ${PROJECT_VERSION})
 
 include(GNUInstallDirs)
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
 include(GNUInstallDirs)
 target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>"
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/apriltag")
 
 # install library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,21 @@ project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
+# Set a default build type if none was specified
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE  STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS  "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 find_package(OpenCV QUIET)
 
 include_directories(.)
 aux_source_directory(common COMMON_SRC)
 set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
-
-set(CMAKE_BUILD_TYPE Release)
 
 # Library
 file(GLOB TAG_FILES ${PROJECT_SOURCE_DIR}/tag*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,38 +101,38 @@ install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "${CMAKE_INSTALL_L
 option(BUILD_PYTHON_WRAPPER "Builds Python wrapper" On)
 
 if(BUILD_PYTHON_WRAPPER)
-SET(Python_ADDITIONAL_VERSIONS 3)
-find_package(PythonLibs)
-execute_process(COMMAND which python3 OUTPUT_QUIET RESULT_VARIABLE Python3_NOT_FOUND)
-execute_process(COMMAND python3 -c "import numpy" RESULT_VARIABLE Numpy_NOT_FOUND)
+    SET(Python_ADDITIONAL_VERSIONS 3)
+    find_package(PythonLibs)
+    execute_process(COMMAND which python3 OUTPUT_QUIET RESULT_VARIABLE Python3_NOT_FOUND)
+    execute_process(COMMAND python3 -c "import numpy" RESULT_VARIABLE Numpy_NOT_FOUND)
 endif(BUILD_PYTHON_WRAPPER)
 
 if (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD_PYTHON_WRAPPER)
-# TODO deal with both python2/3
-execute_process(COMMAND python3 ${PROJECT_SOURCE_DIR}/python_build_flags.py OUTPUT_VARIABLE PY_OUT)
-set(PY_VARS CFLAGS LDFLAGS LINKER EXT_SUFFIX)
-cmake_parse_arguments(PY "" "${PY_VARS}" "" ${PY_OUT})
-separate_arguments(PY_CFLAGS)
-separate_arguments(PY_LDFLAGS)
+    # TODO deal with both python2/3
+    execute_process(COMMAND python3 ${PROJECT_SOURCE_DIR}/python_build_flags.py OUTPUT_VARIABLE PY_OUT)
+    set(PY_VARS CFLAGS LDFLAGS LINKER EXT_SUFFIX)
+    cmake_parse_arguments(PY "" "${PY_VARS}" "" ${PY_OUT})
+    separate_arguments(PY_CFLAGS)
+    separate_arguments(PY_LDFLAGS)
 
-foreach(X detect py_type)
-add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/apriltag_${X}.docstring.h
-    COMMAND < ${PROJECT_SOURCE_DIR}/apriltag_${X}.docstring sed 's/\"/\\\\\"/g\; s/^/\"/\; s/$$/\\\\n\"/\;' > apriltag_${X}.docstring.h
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-endforeach()
+    foreach(X detect py_type)
+    add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/apriltag_${X}.docstring.h
+        COMMAND < ${PROJECT_SOURCE_DIR}/apriltag_${X}.docstring sed 's/\"/\\\\\"/g\; s/^/\"/\; s/$$/\\\\n\"/\;' > apriltag_${X}.docstring.h
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    endforeach()
 
-add_custom_command(OUTPUT apriltag_pywrap.o
-    COMMAND ${CMAKE_C_COMPILER} ${PY_CFLAGS} -I${PROJECT_BINARY_DIR} -c -o apriltag_pywrap.o ${PROJECT_SOURCE_DIR}/apriltag_pywrap.c
-    DEPENDS ${PROJECT_SOURCE_DIR}/apriltag_pywrap.c ${PROJECT_BINARY_DIR}/apriltag_detect.docstring.h ${PROJECT_BINARY_DIR}/apriltag_py_type.docstring.h)
-add_custom_command(OUTPUT apriltag${PY_EXT_SUFFIX}
-    COMMAND ${PY_LINKER} ${PY_LDFLAGS} -Wl,-rpath,lib apriltag_pywrap.o $<TARGET_FILE:apriltag> -o apriltag${PY_EXT_SUFFIX}
-    DEPENDS ${PROJECT_NAME} apriltag_pywrap.o)
-add_custom_target(apriltag_python ALL
-    DEPENDS apriltag${PY_EXT_SUFFIX})
+    add_custom_command(OUTPUT apriltag_pywrap.o
+        COMMAND ${CMAKE_C_COMPILER} ${PY_CFLAGS} -I${PROJECT_BINARY_DIR} -c -o apriltag_pywrap.o ${PROJECT_SOURCE_DIR}/apriltag_pywrap.c
+        DEPENDS ${PROJECT_SOURCE_DIR}/apriltag_pywrap.c ${PROJECT_BINARY_DIR}/apriltag_detect.docstring.h ${PROJECT_BINARY_DIR}/apriltag_py_type.docstring.h)
+    add_custom_command(OUTPUT apriltag${PY_EXT_SUFFIX}
+        COMMAND ${PY_LINKER} ${PY_LDFLAGS} -Wl,-rpath,lib apriltag_pywrap.o $<TARGET_FILE:apriltag> -o apriltag${PY_EXT_SUFFIX}
+        DEPENDS ${PROJECT_NAME} apriltag_pywrap.o)
+    add_custom_target(apriltag_python ALL
+        DEPENDS apriltag${PY_EXT_SUFFIX})
 
-execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
-string(STRIP ${PY_DEST} PY_DEST)
-install(CODE "execute_process(COMMAND cp ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} ${PY_DEST})")
+    execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
+    string(STRIP ${PY_DEST} PY_DEST)
+    install(CODE "execute_process(COMMAND cp ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} ${PY_DEST})")
 endif (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD_PYTHON_WRAPPER)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 find_package(OpenCV QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/apriltag")
 
-# install library
-install(TARGETS ${PROJECT_NAME} EXPORT apriltagTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
 
 # install header file hierarchy
 file(GLOB_RECURSE HEADER_FILES RELATIVE ${PROJECT_SOURCE_DIR} *.h)
@@ -54,15 +49,45 @@ foreach(HEADER ${HEADER_FILES})
 endforeach()
 
 # export library
-install(EXPORT apriltagTargets
-    FILE apriltagTargets.cmake
-    NAMESPACE apriltag::
-    DESTINATION share/apriltag/cmake
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+        "CMake/apriltagConfig.cmake.in"
+        "${project_config}"
+        INSTALL_DESTINATION "${config_install_dir}"
 )
-install(FILES CMake/apriltagConfig.cmake DESTINATION share/apriltag/cmake)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVersion)
+
+
+# install library
+install(TARGETS ${PROJECT_NAME} EXPORT ${targets_export_name}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+
+install(EXPORT ${targets_export_name}
+    NAMESPACE apriltag::
+    DESTINATION ${config_install_dir})
+
+install(FILES ${project_config} ${version_config} DESTINATION ${config_install_dir})
+
 export(TARGETS apriltag
     NAMESPACE apriltag::
-    FILE apriltagTargets.cmake)
+    FILE ${generated_dir}/${targets_export_name}.cmake)
 
 FILE(READ apriltag.pc.in PKGC)
 STRING(REGEX REPLACE "^prefix=" "prefix=${CMAKE_INSTALL_PREFIX}" PKGC_CONF "${PKGC}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,12 @@ export(TARGETS apriltag
     NAMESPACE apriltag::
     FILE ${generated_dir}/${targets_export_name}.cmake)
 
+
+# install pkgconfig related files
 FILE(READ apriltag.pc.in PKGC)
 STRING(REGEX REPLACE "^prefix=" "prefix=${CMAKE_INSTALL_PREFIX}" PKGC_CONF "${PKGC}" )
 FILE(WRITE ${PROJECT_BINARY_DIR}/apriltag.pc ${PKGC_CONF})
-install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "lib/pkgconfig/")
+install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 
 # Python wrapper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
-project(apriltag)
+project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
+
 
 find_package(OpenCV QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 
 find_package(OpenCV QUIET)
 
-include_directories(.)
 aux_source_directory(common COMMON_SRC)
 set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ else()
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION ${PROJECT_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
 
 include(GNUInstallDirs)
 target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
Here are few fixes and refactoring of the CMakeLists file to make the export more standard (in terms of modern cmake).

* add version and languages to project() so the library version can be defined once and then used as ${PROJECT_VERSION}

* Added two options:
   * Standard BUILD_SHARED_LIBS (Default ON) to enable building shared or static libs
   * CMAKE_BUILD_TYPE will default to release if not specified

* removed `include_directory()`, its use is not recommended in modern cmake, better use per target includes.

* add a debug postfix when the library is built in debug (it adds the standard "d" at the end of the name)

* refactoring of the install/export of cmake config files, most notably
   * the config file is now parametric and generated automatically
   * a version file is generated to allow dealing with compatibility (fixes #116 )
   * all generated files are saved in the build directory under a "generated" folder
   * cmake config files are installed in lib/cmake rather than share (it is more "standard")

* [minor] fixed indentation for the python part

 PS
If i may, I'd suggest following a more standard organization of the repository, collecting all the code out of the root folder into a `src` subfolder or something like that. I can propose it in another PR in case.