### PR TITLE
python fix for #125

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ To install to a different directory than /usr/local:
 
     $ PREFIX=/some/path sudo make install
 
+Make sure your environment is properly set, if not done previously:
+
+Add the following to your .bashrc:
+
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+then
+
+    $ source ~/.bashrc
+
+and finally:
+
+    $ sudo ldconfig
+
 
 Flexible Layouts
 ================

--- a/apriltag_detect.docstring
+++ b/apriltag_detect.docstring
@@ -8,7 +8,7 @@ SYNOPSIS
 
     imagepath = '/tmp/tst.jpg'
     image     = cv2.imread(imagepath, cv2.IMREAD_GRAYSCALE)
-    detector = apriltag("tag36h11")
+    detector = apriltag.apriltag("tag36h11")
 
     detections = detector.detect(image)
 

--- a/apriltag_py_type.docstring
+++ b/apriltag_py_type.docstring
@@ -8,7 +8,7 @@ SYNOPSIS
 
     imagepath = '/tmp/tst.jpg'
     image     = cv2.imread(imagepath, cv2.IMREAD_GRAYSCALE)
-    detector = apriltag("tag36h11")
+    detector = apriltag.apriltag("tag36h11")
 
     detections = detector.detect(image)
 


### PR DESCRIPTION
Partially closes #125.

The [Python portion of the Wiki](https://github.com/AprilRobotics/apriltag/wiki/AprilTag-User-Guide#python) also needs to be changed, but is not actually part of the repo, so I can't edit/pull request it.

the following example line needs to be changed from: 
`detector = apriltag("tagStandard41h12")`
to:
`detector = apriltag.apriltag("tagStandard41h12")`