### PR TITLE
don't overwrite CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(.)
 aux_source_directory(common COMMON_SRC)
 set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
 
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "choose the type of build")
 
 # Library
 file(GLOB TAG_FILES ${PROJECT_SOURCE_DIR}/tag*.c)


### PR DESCRIPTION
Title says it all.
The overwriting of the cmake build type breaks my ROS2 build.
Note: this is fixed in PR #117 but that one has not seen progress in a while.
Please consider this PR, thanks!
