### PR TITLE
Optionally build static version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
 
-cmake_policy(SET CMP0077 NEW)
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # Set a default build type if none was specified

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,7 @@ set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
 
 # Library
 file(GLOB TAG_FILES ${PROJECT_SOURCE_DIR}/tag*.c)
-if(BUILD_SHARED_LIBS)
-    add_library(${PROJECT_NAME} SHARED ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
-else()
-    add_library(${PROJECT_NAME} STATIC ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
-endif()
+add_library(${PROJECT_NAME} ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
 
 if (MSVC)
     # FindThreads will not find pthread.h with MSVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,12 @@ set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
 
 # Library
 file(GLOB TAG_FILES ${PROJECT_SOURCE_DIR}/tag*.c)
-add_library(${PROJECT_NAME} SHARED ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
+if(BUILD_SHARED_LIBS)
+    add_library(${PROJECT_NAME} SHARED ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
+else()
+    add_library(${PROJECT_NAME} STATIC ${APRILTAG_SRCS} ${COMMON_SRC} ${TAG_FILES})
+endif()
+
 if (MSVC)
     # FindThreads will not find pthread.h with MSVC
     # winmm is necessary for __imp_timeGetTime
@@ -97,7 +102,8 @@ install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "${CMAKE_INSTALL_L
 
 
 # Python wrapper
-option(BUILD_PYTHON_WRAPPER "Builds Python wrapper" On)
+include(CMakeDependentOption)
+cmake_dependent_option(BUILD_PYTHON_WRAPPER "Builds Python wrapper" ON BUILD_SHARED_LIBS OFF)
 
 if(BUILD_PYTHON_WRAPPER)
     SET(Python_ADDITIONAL_VERSIONS 3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
 
+cmake_policy(SET CMP0077 NEW)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # Set a default build type if none was specified


### PR DESCRIPTION
Uses the BUILD_SHARED_LIBS option to enable static builds if desired. Also disables the build of the python wrapper when building the static version.