### PR TITLE
Add ALIAS target "apriltag" for "apriltag::apriltag" to achieve backwards compatibility

### DIFF
--- a/CMake/apriltagConfig.cmake.in
+++ b/CMake/apriltagConfig.cmake.in
@@ -1,9 +1,10 @@
 @PACKAGE_INIT@
 
-if (NOT MSVC) 
-    include(CMakeFindDependencyMacro)
-    find_dependency(Threads)
+if(NOT MSVC)
+  include(CMakeFindDependencyMacro)
+  find_dependency(Threads)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")
+

--- a/CMake/apriltagConfig.cmake.in
+++ b/CMake/apriltagConfig.cmake.in
@@ -8,3 +8,9 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")
 
+if(NOT TARGET apriltag)
+  # Make imported target globally visible in order to create an ALIAS
+  set_target_properties(apriltag::apriltag PROPERTIES IMPORTED_GLOBAL TRUE)
+  # Create alias for backwards compatibility with 3.1.2 and earlier (will be removed in the future - please migrate to apriltag::apriltag)
+  add_library(apriltag ALIAS apriltag::apriltag)
+endif()


### PR DESCRIPTION
In order to maintain backwards compatibility with versions 3.1.2 and earlier where target "apriltag" existed, add an ALIAS target to the new target with namespace ("apriltag::apriltag") introduced in commit 35f4ef2

This is a potential solution to unblock a release (#166)