### PR TITLE
Fix for #167 for CMake versions <3.11

### DIFF
--- a/CMake/apriltagConfig.cmake.in
+++ b/CMake/apriltagConfig.cmake.in
@@ -8,8 +8,9 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")
 
-if(NOT TARGET apriltag)
+if(NOT TARGET apriltag AND ${CMAKE_VERSION} VERSION_GREATER "3.10.99")
   # Make imported target globally visible in order to create an ALIAS
+  # IMPORTED_GLOBAL is only available in CMake 3.11+
   set_target_properties(apriltag::apriltag PROPERTIES IMPORTED_GLOBAL TRUE)
   # Create alias for backwards compatibility with 3.1.2 and earlier (will be removed in the future - please migrate to apriltag::apriltag)
   add_library(apriltag ALIAS apriltag::apriltag)


### PR DESCRIPTION
IMPORTED_GLOBAL is only available in CMake 3.11 and newer. Ubuntu 18.04
ships with CMake 3.10 and thus failed to configure projects using
AprilTag v3.15. This fix only activates the backwards-compatible ALIAS
target when using a new, supported CMake version.