### PR TITLE
Remove exit from quick decode init

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -285,8 +285,8 @@ static size_t quick_decode_init(apriltag_family_t *family, int maxhamming)
         }
 
         printf("quick decode: longest run: %d, average run %.3f\n", longest_run, 1.0 * run_sum / run_count);
-        return APRILTAG_DETECTOR_ADD_FAMILY_OK;
     }
+    return APRILTAG_DETECTOR_ADD_FAMILY_OK;
 }
 
 // returns an entry with hamming set to 255 if no decode was found.

--- a/apriltag.h
+++ b/apriltag.h
@@ -41,6 +41,7 @@ extern "C" {
 #include <pthread.h>
 
 #define APRILTAG_TASKS_PER_THREAD_TARGET 10
+#define APRILTAG_DETECTOR_ADD_FAMILY_OK 0
 
 struct quad
 {
@@ -235,14 +236,16 @@ apriltag_detector_t *apriltag_detector_create();
 
 // add a family to the apriltag detector. caller still "owns" the family.
 // a single instance should only be provided to one apriltag detector instance.
-void apriltag_detector_add_family_bits(apriltag_detector_t *td, apriltag_family_t *fam, int bits_corrected);
+// returns APRILTAG_DETECTOR_ADD_FAMILY_OK on success and the number of bytes required to use the family on failure
+size_t apriltag_detector_add_family_bits(apriltag_detector_t *td, apriltag_family_t *fam, int bits_corrected);
 
 // Tunable, but really, 2 is a good choice. Values of >=3
 // consume prohibitively large amounts of memory, and otherwise
 // you want the largest value possible.
-static inline void apriltag_detector_add_family(apriltag_detector_t *td, apriltag_family_t *fam)
+// returns APRILTAG_DETECTOR_ADD_FAMILY_OK on success and the number of bytes required to use the family on failure
+static inline size_t apriltag_detector_add_family(apriltag_detector_t *td, apriltag_family_t *fam)
 {
-    apriltag_detector_add_family_bits(td, fam, 2);
+    return apriltag_detector_add_family_bits(td, fam, 2);
 }
 
 // does not deallocate the family.

--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -139,7 +139,7 @@ apriltag_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     }
 
     if(apriltag_detector_add_family_bits(self->td, self->tf, maxhamming) != APRILTAG_DETECTOR_ADD_FAMILY_OK){
-        PyErr_Format(PyExc_RuntimeError, "Adding tag family failed. Try reducing maxhamming from: %d", maxhamming);
+        PyErr_Format(PyExc_RuntimeError, "Adding tag family failed. Try reducing maxhamming from %d.", maxhamming);
         goto done;
     }
 

--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -138,7 +138,11 @@ apriltag_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         goto done;
     }
 
-    apriltag_detector_add_family_bits(self->td, self->tf, maxhamming);
+    if(apriltag_detector_add_family_bits(self->td, self->tf, maxhamming) != APRILTAG_DETECTOR_ADD_FAMILY_OK){
+        PyErr_Format(PyExc_RuntimeError, "Adding tag family failed. Try reducing maxhamming from: %d", maxhamming);
+        goto done;
+    }
+
     self->td->quad_decimate       = decimate;
     self->td->quad_sigma          = blur;
     self->td->nthreads            = Nthreads;

--- a/example/apriltag_demo.c
+++ b/example/apriltag_demo.c
@@ -104,7 +104,9 @@ int main(int argc, char *argv[])
     }
 
     apriltag_detector_t *td = apriltag_detector_create();
-    apriltag_detector_add_family_bits(td, tf, getopt_get_int(getopt, "hamming"));
+    if(apriltag_detector_add_family_bits(td, tf, getopt_get_int(getopt, "hamming")) !=APRILTAG_DETECTOR_ADD_FAMILY_OK){
+        exit(-1);
+    }
     td->quad_decimate = getopt_get_double(getopt, "decimate");
     td->quad_sigma = getopt_get_double(getopt, "blur");
     td->nthreads = getopt_get_int(getopt, "threads");

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -99,7 +99,9 @@ int main(int argc, char *argv[])
 
 
     apriltag_detector_t *td = apriltag_detector_create();
-    apriltag_detector_add_family(td, tf);
+    if(apriltag_detector_add_family_bits(td, tf, getopt_get_int(getopt, "hamming")) !=APRILTAG_DETECTOR_ADD_FAMILY_OK){
+        exit(-1);
+    }
     td->quad_decimate = getopt_get_double(getopt, "decimate");
     td->quad_sigma = getopt_get_double(getopt, "blur");
     td->nthreads = getopt_get_int(getopt, "threads");

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
     getopt_add_bool(getopt, 'q', "quiet", 0, "Reduce output");
     getopt_add_string(getopt, 'f', "family", "tag36h11", "Tag family to use");
     getopt_add_int(getopt, 't', "threads", "1", "Use this many CPU threads");
+    getopt_add_int(getopt, 'a', "hamming", "1", "Detect tags with up to this many bit errors.");
     getopt_add_double(getopt, 'x', "decimate", "2.0", "Decimate input image by this factor");
     getopt_add_double(getopt, 'b', "blur", "0.0", "Apply low-pass blur to input");
     getopt_add_bool(getopt, '0', "refine-edges", 1, "Spend more time trying to align edges of tags");


### PR DESCRIPTION
This PR aims to address issue #182.

I have defined the flag `APRILTAG_DETECTOR_ADD_FAMILY_OK` which is returned from  `apriltag_detector_add_family_bits` and `apriltag_detector_add_family` if the family provides preprocessor codes (`fam->impl`) or if `quick_decode_init` succeeds.

If the `add_family` functions are unsuccessful they return the number of bytes requested. This is handy for more informative error information but you might prefer to return just a fixed value.

I have modified the two examples - firstly to add the test for success and a call to `exit()` on failure and also to add the ability to specify the max hamming value for the `opencv_demo`.

I have also modified the python wrapper to check for success and return a (hopefully) meaningful error on failure.

I might consider these to be breaking changes to the API even though the original behaviour was non-ideal, but I shall leave that to you, the maintainers, to decide; I could extend the current API with a new call that adds the tag-family without calling exit and leave the external behaviour of the existing functions unchanged. Let me know if this would be preferred.

Quick tests of the functionality seem ok but I am happy to take another pass at anything and please feel free to make changes to the PR as you wish.

Cheers

John
