### PR TITLE
switch to OpenCV4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(apriltag VERSION 3.1.0 LANGUAGES C CXX)
+project(apriltag VERSION 3.2.0 LANGUAGES C CXX)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CXX = g++
 
-CPPFLAGS = -I..
+CPPFLAGS = -I.. `pkg-config --cflags opencv4`
 CFLAGS = -g -std=gnu99 -Wall -Wno-unused-parameter -Wno-unused-function -O3
 CXXFLAGS = -g -Wall -O3
 LDFLAGS = -lpthread -lm
@@ -17,7 +17,7 @@ apriltag_demo: apriltag_demo.o ../libapriltag.a
 
 opencv_demo: opencv_demo.o ../libapriltag.a
 	@echo "   [$@]"
-	@$(CXX) -o $@ $^ $(LDFLAGS) `pkg-config --libs opencv`
+	@$(CXX) -o $@ $^ $(LDFLAGS) `pkg-config --libs opencv4`
 
 %.o: %.c
 	@echo "   $@"

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
-  <version>3.1.7</version>
+  <version>3.2.0</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>


### PR DESCRIPTION
This switches the Makefile to use OpenCV 4 and also sets the include path correctly via `pkg-config --cflags`.