### PR TITLE
Fix `refine_edges()` Corner Ordering

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -868,8 +868,8 @@ static void refine_edges(apriltag_detector_t *td, image_u8_t *im_orig, struct qu
             double L0 = W00*B0 + W01*B1;
 
             // compute intersection
-            quad->p[i][0] = lines[i][0] + L0*A00;
-            quad->p[i][1] = lines[i][1] + L0*A10;
+            quad->p[(i+1)&3][0] = lines[i][0] + L0*A00;
+            quad->p[(i+1)&3][1] = lines[i][1] + L0*A10;
         } else {
             // this is a bad sign. We'll just keep the corner we had.
 //            printf("bad det: %15f %15f %15f %15f %15f\n", A00, A11, A10, A01, det);


### PR DESCRIPTION
The output quad corners of refine edges are rotated one index clockwise from the input quad corners. 

This is not a major issue, except when the intersection cannot be found, or the edge cannot be refined. In these error cases, the algorithm does not modify the original corner, but the original corner index is at the wrong index. 

When refining the edges, the edges are stored in an array. Edge 0 is the line from corners 0-1. Edge 1 is corners 1-2. 
This means that the intersection of edge 0 and edge 1 is corner 1. The current algorithm makes the assumption that the intersection of edge 0 and 1 will be corner 0. 

This PR fixes the ordering so that the output quad has the same corner indexes as the input quad, which also solves the ordering issues for the fallback cases