### PR TITLE
Fixed a memory leak in matd_svd_tall

### DIFF
--- a/common/matd.c
+++ b/common/matd.c
@@ -1105,8 +1105,10 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             double mag = sqrt(mag2);
 
             // this case can occur when the vectors are already perpendicular
-            if (mag == 0)
+            if (mag == 0) {
+                free(v);
                 continue;
+            }
 
             for (int i = 0; i < vlen; i++)
                 v[i] /= mag;


### PR DESCRIPTION
Hello,
I happened to fall on this potential memory leak browsing your code.
We assign `v` line 1088: `double *v = malloc(sizeof(double)*vlen);`.
It seems that we never free it if `mag == 0`.
I thought you might like a PR. Feel free to use it or not.

Thanks a lot for your work and for your time! :)