### PR TITLE
build with AddressSanitizer to find memory issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,26 @@ if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)
 endif()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(ASAN "Use AddressSanitizer for debug builds to detect memory issues" OFF)
+
+if (ASAN)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} \
+        -fsanitize=address \
+        -fsanitize=bool \
+        -fsanitize=bounds \
+        -fsanitize=enum \
+        -fsanitize=float-cast-overflow \
+        -fsanitize=float-divide-by-zero \
+        -fsanitize=nonnull-attribute \
+        -fsanitize=returns-nonnull-attribute \
+        -fsanitize=signed-integer-overflow \
+        -fsanitize=undefined \
+        -fsanitize=vla-bound \
+        -fno-sanitize=alignment \
+        -fsanitize=leak \
+        -fsanitize=object-size \
+    ")
+endif()
 
 # Set a default build type if none was specified
 set(default_build_type "Release")


### PR DESCRIPTION
Build with `-DASAN=ON` to enable AddressSanitizer. Memory issues will be shown on screen.
Some backtraces will be shortened. Run with
`ASAN_OPTIONS=fast_unwind_on_malloc=0 <exec>`
to show full backtrace.