### PR TITLE
Updating apriltag demo with image statistics (path and size)

### DIFF
--- a/example/apriltag_demo.c
+++ b/example/apriltag_demo.c
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
                 int err = 0;
                 pjpeg_t *pjpeg = pjpeg_create_from_file(path, 0, &err);
                 if (pjpeg == NULL) {
-                    printf("pjpeg error %d\n", err);
+                    printf("pjpeg failed to load: %s, error %d\n", path, err);
                     continue;
                 }
 
@@ -189,6 +189,8 @@ int main(int argc, char *argv[])
                 printf("couldn't load %s\n", path);
                 continue;
             }
+
+            printf("image: %s %dx%d\n", path, im->width, im->height);
 
             zarray_t *detections = apriltag_detector_detect(td, im);
 


### PR DESCRIPTION
    ./apriltag_demo ~/Downloads/nori-5-640.jpg --decimate=0 --blur=5 --debug --threads=8
    loading /Users/jacob.repp/Downloads/nori-5-640.jpg
    image: /Users/jacob.repp/Downloads/nori-5-640.jpg 480x640
     0                             init        0.007000 ms        0.007000 ms
     1                       blur/sharp       32.702000 ms       32.709000 ms
     2                        threshold        6.013000 ms       38.722000 ms
     3                        unionfind       13.113000 ms       51.835000 ms
     4                    make clusters        6.358000 ms       58.193000 ms
     5            fit quads to clusters       30.752000 ms       88.945000 ms
     6                            quads        0.216000 ms       89.161000 ms
     7                decode+refinement        6.644000 ms       95.805000 ms
     8                        reconcile        0.002000 ms       95.807000 ms
     9                     debug output       67.118000 ms      162.925000 ms
    10                          cleanup        0.009000 ms      162.934000 ms
    hamm     0     0     0     0     0     0     0     0     0     0      162.927    20
    Summary
    hamm     0     0     0     0     0     0     0     0     0     0      162.927    20