### PR TITLE
Fixing compiler warning in unionfind.h for maxint

### DIFF
--- a/common/unionfind.h
+++ b/common/unionfind.h
@@ -54,7 +54,7 @@ static inline unionfind_t *unionfind_create(uint32_t maxid)
     unionfind_t *uf = (unionfind_t*) calloc(1, sizeof(unionfind_t));
     uf->maxid = maxid;
     uf->data = (struct ufrec*) malloc((maxid+1) * sizeof(struct ufrec));
-    for (int i = 0; i <= maxid; i++) {
+    for (uint32_t i = 0; i <= maxid; i++) {
         uf->data[i].size = 1;
         uf->data[i].parent = i;
     }


### PR DESCRIPTION
Parameter type is a uint32_t, causes compiler warning.