### PR TITLE
Adding check for length 0 in fit_line to avoid NaN

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -241,8 +241,13 @@ void fit_line(struct line_fit_pt *lfps, int sz, int i0, int i1, double *lineparm
         }
 
         double length = sqrtf(M);
-        lineparm[2] = nx/length;
-        lineparm[3] = ny/length;
+        if (length > 0) {
+            lineparm[2] = nx / length;
+            lineparm[3] = ny / length;
+        } else {
+            lineparm[2] = 0;
+            lineparm[3] = 0;
+        }
     }
 
     // sum of squared errors =
@@ -921,7 +926,6 @@ int fit_quad(
         // compute intersection
         quad->p[i][0] = lines[i][0] + L0*A00;
         quad->p[i][1] = lines[i][1] + L0*A10;
-
         res = 1;
     }
 


### PR DESCRIPTION
When dividing by 0 a NaN is introduced to the lineparm, this is eventually introduced to the quads and causes failures later in detection such as quad building.

I tested this with no failing inputs such as https://github.com/AprilRobotics/apriltag/issues/72 as well as verifying I didn't introduce regressions in known good detections.
