### PR TITLE
Safely fail homography building when failing row swap

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -501,6 +501,7 @@ static int quad_update_homographies(struct quad *quad)
     if (quad->H != NULL) {
         quad->Hinv = matd_inverse(quad->H);
         if (quad->Hinv != NULL) {
+	    // Success!
             return 0;
         }
         matd_destroy(quad->H);

--- a/apriltag.c
+++ b/apriltag.c
@@ -444,6 +444,7 @@ static matd_t* homography_compute2(double c[4][4]) {
 
         if (max_val < epsilon) {
             fprintf(stderr, "WRN: Matrix is singular.\n");
+            return NULL;
         }
 
         // Swap to get best row.
@@ -497,12 +498,14 @@ static int quad_update_homographies(struct quad *quad)
 
     // XXX Tunable
     quad->H = homography_compute2(corr_arr);
-
-    quad->Hinv = matd_inverse(quad->H);
-
-    if (quad->H && quad->Hinv)
-        return 0;
-
+    if (quad->H != NULL) {
+        quad->Hinv = matd_inverse(quad->H);
+        if (quad->Hinv != NULL) {
+            return 0;
+        }
+        matd_destroy(quad->H);
+        quad->H = NULL;
+    }
     return -1;
 }
 
@@ -895,7 +898,7 @@ static void quad_decode_task(void *_u)
         }
 
         // make sure the homographies are computed...
-        if (quad_update_homographies(quad_original))
+        if (quad_update_homographies(quad_original) != 0)
             continue;
 
         for (int famidx = 0; famidx < zarray_size(td->tag_families); famidx++) {


### PR DESCRIPTION
When failing to solve the quad homography solution exit the function with a NULL and handle the failure in the caller.

This prevents writing to invalid memory locations later in the function.

Note that the trigger for this is a NaN earlier in line building. There may be some degenerate cases in the eigenvalue solve for line building that needs additional testing.

This change does not introduce any regressions to positive test cases.

See: 
https://github.com/AprilRobotics/apriltag/issues/72
https://github.com/AprilRobotics/apriltag/issues/154