### PR TITLE
[cmake] sanitazier flags in C_FLAGS instead of CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ASAN "Use AddressSanitizer for debug builds to detect memory issues" OFF)
 
 if (ASAN)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} \
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} \
         -fsanitize=address \
         -fsanitize=bool \
         -fsanitize=bounds \


### PR DESCRIPTION
Building with sanitizers is not currently working because the code is C and the flags are set for CXX instead.
Just need to use `CMAKE_C_FLAGS_DEBUG`