### PR TITLE
[apriltag_demo] improving perf testing

### DIFF
--- a/common/timeprofile.h
+++ b/common/timeprofile.h
@@ -93,9 +93,8 @@ static inline void timeprofile_display(timeprofile_t *tp)
 
         zarray_get_volatile(tp->stamps, i, &stamp);
 
-        double cumtime = (stamp->utime - tp->utime)/1000000.0;
-
-        double parttime = (stamp->utime - lastutime)/1000000.0;
+        double cumtime = (stamp->utime - tp->utime) / 1000000.0;
+        double parttime = (stamp->utime - lastutime) / 1000000.0;
 
         printf("%2d %32s %15f ms %15f ms\n", i, stamp->name, parttime*1000, cumtime*1000);
 
@@ -103,7 +102,7 @@ static inline void timeprofile_display(timeprofile_t *tp)
     }
 }
 
-static inline uint64_t timeprofile_total_utime(timeprofile_t *tp)
+static inline uint64_t timeprofile_total_ms(timeprofile_t *tp)
 {
     if (zarray_size(tp->stamps) == 0)
         return 0;
@@ -112,7 +111,7 @@ static inline uint64_t timeprofile_total_utime(timeprofile_t *tp)
     zarray_get_volatile(tp->stamps, 0, &first);
     zarray_get_volatile(tp->stamps, zarray_size(tp->stamps) - 1, &last);
 
-    return last->utime - first->utime;
+    return (last->utime - first->utime) / 1000.0;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
When running multiple iterations we want to focus the profiling time on the core algorithm. This change separates image loading from detection. Each iteration is the array of loaded images. A summary is printed at the end. 

Improvements to running with -i N -q which allows iterations
of 1000-10000 to be easily tested in a console on modest hardware and prevents measuring the print time (around .8ms on my machine)

An additional cleanup to the called functions for profiling to place them in ms for parity with the existing reporting.
```
./apriltag_demo -i 1000 -q nori-5-640.jpg
loaded image: nori-5-640.jpg 480x640
iter 1 / 1000
iter 101 / 1000
iter 201 / 1000
iter 301 / 1000
iter 401 / 1000
iter 501 / 1000
iter 601 / 1000
iter 701 / 1000
iter 801 / 1000
iter 901 / 1000
Summary
hamm  1000     0     0     0     0     0     0     0     0     0
time 12700.00ms avg_time 12.70ms quads 18000 avg_quads    18 detections  1000 avg_detections     1
```