### PR TITLE
Fixing zhash/ASAN errors, improve hash

### DIFF
--- a/common/zhash.c
+++ b/common/zhash.c
@@ -540,14 +540,15 @@ uint32_t zhash_str_hash(const void *_a)
 
     char *a = * (char**)_a;
 
-    int32_t hash = 0;
+    uint32_t hash = 0;
     while (*a != 0) {
-        hash = (hash << 7) + (hash >> 23);
-        hash += *a;
+        // optimization of hash x FNV_prime
+        hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+        hash ^= *a;
         a++;
     }
 
-    return (uint32_t) hash;
+    return hash;
 }
 
 


### PR DESCRIPTION
```../common/zhash.c:545:22: runtime error: left shift of 211382645 by 7 places cannot be represented in type 'int'```

Fixed the ASAN error
Noticed the hash was lacking so improved the string hash function to use an optimized [FNV](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) - it's a few more hashes and a multiply.

Currently, this str hash is only used to index command-line arguments.