### PR TITLE
Replaced calls to exit()

### DIFF
--- a/apriltag_pose.c
+++ b/apriltag_pose.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdio.h>
 
+#include "common/debug_print.h"
 #include "apriltag_pose.h"
 #include "common/homography.h"
 
@@ -436,7 +437,7 @@ matd_t* fix_pose_ambiguities(matd_t** v, matd_t** p, matd_t* t, matd_t* R, int n
         matd_destroy(R_beta);
     } else if (n_minima > 1)  {
         // This can happen if our prior pose estimate was not very good.
-        fprintf(stderr, "Error, more than one new minimum found.\n");
+        debug_print("Error, more than one new minimum found.\n");
     }
     matd_destroy(I3);
     matd_destroy(M1);

--- a/common/debug_print.h
+++ b/common/debug_print.h
@@ -1,0 +1,47 @@
+/* Copyright (C) 2013-2016, The Regents of The University of Michigan.
+All rights reserved.
+This software was developed in the APRIL Robotics Lab under the
+direction of Edwin Olson, ebolson@umich.edu. This software may be
+available under alternative licensing terms; contact the address above.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the Regents of The University of Michigan.
+*/
+#pragma once
+
+#if !defined(NDEBUG) || defined(_DEBUG)
+
+#include <string.h>
+#include <stdio.h>
+#define DEBUG 1
+
+#else
+#define DEBUG 0
+#endif
+
+#ifdef _WIN32
+#define debug_print(fmt, ...) \
+        do { if (DEBUG) fprintf(stderr, "%s:%d:%s(): " fmt, strrchr("\\"__FILE__,'\\')+1, \
+                                __LINE__, __func__, __VA_ARGS__); fflush(stderr);} while (0)
+#else
+#define debug_print(fmt, ...) \
+        do { if (DEBUG) fprintf(stderr, "%s:%d:%s(): " fmt, strrchr("/"__FILE__,'/')+1, \
+                                __LINE__, __func__, ##__VA_ARGS__); fflush(stderr);} while (0)
+#endif

--- a/common/g2d.c
+++ b/common/g2d.c
@@ -403,10 +403,12 @@ int g2d_polygon_contains_point(const zarray_t *poly, double q[2])
 
     int v = (quad_acc >= 2) || (quad_acc <= -2);
 
-    if (0 && v != g2d_polygon_contains_point_ref(poly, q)) {
+    #if 0
+    if (v != g2d_polygon_contains_point_ref(poly, q)) {
         printf("FAILURE %d %d\n", v, quad_acc);
         exit(-1);
     }
+    #endif
 
     return v;
 }

--- a/common/matd.c
+++ b/common/matd.c
@@ -36,6 +36,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 #include "common/math_util.h"
 #include "common/svd22.h"
 #include "common/matd.h"
+#include "common/debug_print.h"
 
 // a matd_t with rows=0 cols=0 is a SCALAR.
 
@@ -781,7 +782,7 @@ static matd_t *matd_op_recurse(const char *expr, int *pos, matd_t *acc, matd_t *
             }
 
             default: {
-                fprintf(stderr, "matd_op(): Unknown character: '%c'\n", expr[*pos]);
+                debug_print("Unknown character: '%c'\n", expr[*pos]);
                 assert(expr[*pos] != expr[*pos]);
             }
         }
@@ -1375,7 +1376,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     free(maxrowidx);
 
     if (!(flags & MATD_SVD_NO_WARNINGS) && iter == maxiters) {
-        printf("WARNING: maximum iters (maximum = %d, matrix %d x %d, max=%.15f)\n",
+        debug_print("WARNING: maximum iters (maximum = %d, matrix %d x %d, max=%.15f)\n",
                iter, A->nrows, A->ncols, maxv);
 
 //        matd_print(A, "%15f");

--- a/common/workerpool.c
+++ b/common/workerpool.c
@@ -24,6 +24,7 @@ The views and conclusions contained in the software and documentation are those
 of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the Regents of The University of Michigan.
 */
+#include <errno.h>
 
 #define __USE_GNU
 #include <pthread.h>
@@ -38,6 +39,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 #endif
 
 #include "workerpool.h"
+#include "debug_print.h"
 
 struct workerpool {
     int nthreads;
@@ -114,8 +116,9 @@ workerpool_t *workerpool_create(int nthreads)
         for (int i = 0; i < nthreads; i++) {
             int res = pthread_create(&wp->threads[i], NULL, worker_thread, wp);
             if (res != 0) {
-                perror("pthread_create");
-                exit(-1);
+                debug_print("Insufficient system resources to create workerpool threads\n");
+                // errno already set to EAGAIN by pthread_create() failure
+                return NULL;
             }
         }
     }

--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -33,6 +33,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 #include <stdint.h>
 
 #include "zmaxheap.h"
+#include "debug_print.h"
 
 #ifdef _WIN32
 static inline long int random(void)
@@ -176,8 +177,7 @@ void zmaxheap_vmap(zmaxheap_t *heap, void (*f)())
         void *p = NULL;
         memcpy(&p, &heap->data[idx*heap->el_sz], heap->el_sz);
         if (p == NULL) {
-            printf("Warning: zmaxheap_vmap item %d is NULL\n", idx);
-            fflush(stdout);
+            debug_print("Warning: zmaxheap_vmap item %d is NULL\n", idx);
         }
         f(p);
     }

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -105,6 +105,12 @@ int main(int argc, char *argv[])
 
     apriltag_detector_t *td = apriltag_detector_create();
     apriltag_detector_add_family(td, tf);
+
+    if (errno == ENOMEM) {
+        printf("Unable to add family to detector due to insufficient memory to allocate the tag-family decoder with the default maximum hamming value of 2. Try choosing an alternative tag family.\n");
+        exit(-1);
+    }
+    
     td->quad_decimate = getopt_get_double(getopt, "decimate");
     td->quad_sigma = getopt_get_double(getopt, "blur");
     td->nthreads = getopt_get_int(getopt, "threads");
@@ -133,6 +139,11 @@ int main(int argc, char *argv[])
         };
 
         zarray_t *detections = apriltag_detector_detect(td, &im);
+
+        if (errno==EAGAIN) {
+            printf("Unable to create the %d threads requested.\n",td->nthreads);
+            exit(-1);
+        }
 
         // Draw detection outlines
         for (int i = 0; i < zarray_size(detections); i++) {


### PR DESCRIPTION
Here is a belated PR for issue #182.

I have removed all the calls to `exit()` that might be encountered and set the `errno` where it isn't already set by the operation that failed.

As the user might not be checking the `errno` values I thought it best to avoid their application crashing by returning an empty detections array, where relevant, to avoid them encountering a null-pointer.

Any feedback is welcome and I am happy to tweak as required.