### PR TITLE
Add back Ubuntu 16.04 support - resolves #244

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         env:
           # ROS 1
+          - {ROS_DISTRO: kinetic}
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
           # ROS 2

--- a/.github/workflows/ros_workspace.yml
+++ b/.github/workflows/ros_workspace.yml
@@ -11,10 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        ros_distribution: [noetic, humble]
+        ros_distribution: [melodic, noetic, humble]
         config: ["default"] # nice name
         cmake_args: ['[ ]'] # empty list of options
-        include:
+        include:         
+          - docker_image: ubuntu:18.04
+            ros_distribution: melodic
+            ros_version: 1
+
           - docker_image: ubuntu:20.04
             ros_distribution: noetic
             ros_version: 1
@@ -40,8 +44,8 @@ jobs:
           apt install --no-install-recommends -y git ca-certificates
 
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+        #with:
+        #  submodules: recursive
 
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@v0.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,8 @@ add_executable(apriltag_demo example/apriltag_demo.c)
 target_link_libraries(apriltag_demo ${PROJECT_NAME})
 
 # opencv_demo
-find_package(OpenCV COMPONENTS core imgproc videoio highgui QUIET)
+# NB: contrib required for TickMeter in OpenCV 2.4. This is only required for 16.04 backwards compatibility and can be removed in the future.
+find_package(OpenCV COMPONENTS core imgproc videoio highgui contrib QUIET)
 if(OpenCV_FOUND)
     add_executable(opencv_demo example/opencv_demo.cc)
     target_link_libraries(opencv_demo apriltag ${OpenCV_LIBRARIES})

--- a/common/workerpool.c
+++ b/common/workerpool.c
@@ -26,6 +26,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 */
 #include <errno.h>
 
+#define _GNU_SOURCE  // Possible fix for 16.04
 #define __USE_GNU
 #include "common/pthreads_cross.h"
 #include <assert.h>

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -26,6 +26,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 */
 
 #include <iostream>
+#include <iomanip>
 
 #include "opencv2/opencv.hpp"
 
@@ -121,9 +122,15 @@ int main(int argc, char *argv[])
     meter.stop();
     cout << "Detector " << famname << " initialized in " 
         << std::fixed << std::setprecision(3) << meter.getTimeSec() << " seconds" << endl;
+#if CV_MAJOR_VERSION > 3
     cout << "  " << cap.get(CAP_PROP_FRAME_WIDTH ) << "x" <<
                     cap.get(CAP_PROP_FRAME_HEIGHT ) << " @" <<
                     cap.get(CAP_PROP_FPS) << "FPS" << endl;
+#else
+    cout << "  " << cap.get(CV_CAP_PROP_FRAME_WIDTH ) << "x" <<
+                    cap.get(CV_CAP_PROP_FRAME_HEIGHT ) << " @" <<
+                    cap.get(CV_CAP_PROP_FPS) << "FPS" << endl;
+#endif
     meter.reset();
 
     Mat frame, gray;


### PR DESCRIPTION
We need to define `_GNU_SOURCE` for the initially reported error to go away. 

Since Ubuntu 16.04 ships by default with OpenCV 2.4, we need further changes for renamed variables and moved modules (`TickMeter` was in `contrib` back in 2.4).

Resolves #244 