### PR TITLE
Fixed refine_edges keyword to allow it to be referenced in Python

### DIFF
--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -98,7 +98,7 @@ apriltag_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
                         "maxhamming",
                         "decimate",
                         "blur",
-                        "refine-edges",
+                        "refine_edges",
                         "debug",
                         NULL };
 


### PR DESCRIPTION
This is to solve Issue #243. The functionality was already there, but "refine-edges" can't be used as a keyword argument in python because of the '-'.