### PR TITLE
declare binary parameters as bool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(apriltag VERSION 3.2.0 LANGUAGES C CXX)
+project(apriltag VERSION 3.3.0 LANGUAGES C CXX)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/apriltag.c
+++ b/apriltag.c
@@ -367,7 +367,7 @@ apriltag_detector_t *apriltag_detector_create()
 
     td->qtp.max_line_fit_mse = 10.0;
     td->qtp.cos_critical_rad = cos(10 * M_PI / 180);
-    td->qtp.deglitch = 0;
+    td->qtp.deglitch = false;
     td->qtp.min_white_black_diff = 5;
 
     td->tag_families = zarray_create(sizeof(apriltag_family_t*));
@@ -376,11 +376,11 @@ apriltag_detector_t *apriltag_detector_create()
 
     td->tp = timeprofile_create();
 
-    td->refine_edges = 1;
+    td->refine_edges = true;
     td->decode_sharpening = 0.25;
 
 
-    td->debug = 0;
+    td->debug = false;
 
     // NB: defer initialization of td->wp so that the user can
     // override td->nthreads.

--- a/apriltag.h
+++ b/apriltag.h
@@ -144,14 +144,14 @@ struct apriltag_detector
     // (e.g. 0.8).
     float quad_sigma;
 
-    // When non-zero, the edges of the each quad are adjusted to "snap
+    // When true, the edges of the each quad are adjusted to "snap
     // to" strong gradients nearby. This is useful when decimation is
     // employed, as it can increase the quality of the initial quad
-    // estimate substantially. Generally recommended to be on (1).
+    // estimate substantially. Generally recommended to be on (true).
     //
     // Very computationally inexpensive. Option is ignored if
     // quad_decimate = 1.
-    int refine_edges;
+    bool refine_edges;
 
     // How much sharpening should be done to decoded images? This
     // can help decode small tags but may or may not help in odd
@@ -160,10 +160,10 @@ struct apriltag_detector
     // The default value is 0.25.
     double decode_sharpening;
 
-    // When non-zero, write a variety of debugging images to the
+    // When true, write a variety of debugging images to the
     // current working directory at various stages through the
     // detection process. (Somewhat slow).
-    int debug;
+    bool debug;
 
     struct apriltag_quad_thresh_params qtp;
 

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1274,7 +1274,7 @@ image_u8_t *threshold(apriltag_detector_t *td, image_u8_t *im)
 
     // this is a dilate/erode deglitching scheme that does not improve
     // anything as far as I can tell.
-    if (0 || td->qtp.deglitch) {
+    if (td->qtp.deglitch) {
         image_u8_t *tmp = image_u8_create(w, h);
 
         for (int y = 1; y + 1 < h; y++) {

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>


### PR DESCRIPTION
Some of the `apriltag_detector_t` parameters are meant to be used as binary flags but stored as an integer with a much larger value range. This makes it difficult from an API perspective to directly grasp the meaning of a parameter. I am proposing here to change the type of `refine_edges`, `debug` and `qtp.deglitch` from `int` to `bool`.

While this is an API change, the impact should be low since previously used `int`s should be cast automatically for `bool`en values.