### PR TITLE
version the pkg-config file and use standard CMake for formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,10 @@ export(TARGETS apriltag
     FILE ${generated_dir}/${targets_export_name}.cmake)
 
 
-# install pkgconfig related files
-FILE(READ apriltag.pc.in PKGC)
-STRING(REGEX REPLACE "^prefix=" "prefix=${CMAKE_INSTALL_PREFIX}" PKGC_CONF "${PKGC}" )
-FILE(WRITE ${PROJECT_BINARY_DIR}/apriltag.pc ${PKGC_CONF})
-install(FILES "${PROJECT_BINARY_DIR}/apriltag.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+# install pkgconfig file
+configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
+install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 
 # Python wrapper

--- a/apriltag.pc.in
+++ b/apriltag.pc.in
@@ -1,10 +1,10 @@
-prefix=
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
 libdir=${exec_prefix}/lib
 
-Name: apriltag
-Description: AprilTag detector library
-Version: 0.10.0
+Name: @PROJECT_NAME@
+Description: AprilTag is a visual fiducial system popular for robotics research.
+Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lapriltag


### PR DESCRIPTION
I noticed that the version on the `apriltag.pc` file was hard coded. CMake provides `configure_file` to format such a file automatically, including the version.