### PR TITLE
Fix OpenCV configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,9 +163,16 @@ add_executable(apriltag_demo example/apriltag_demo.c)
 target_link_libraries(apriltag_demo ${PROJECT_NAME})
 
 # opencv_demo
-# NB: contrib required for TickMeter in OpenCV 2.4. This is only required for 16.04 backwards compatibility and can be removed in the future.
-find_package(OpenCV COMPONENTS core imgproc videoio highgui contrib QUIET)
+set(_OpenCV_REQUIRED_COMPONENTS core imgproc videoio highgui)
+find_package(OpenCV COMPONENTS ${_OpenCV_REQUIRED_COMPONENTS} QUIET CONFIG)
 if(OpenCV_FOUND)
+    # NB: contrib required for TickMeter in OpenCV 2.4. This is only required for 16.04 backwards compatibility and can be removed in the future.
+    #     If we add it to the find_package initially, the demo won't build for newer OpenCV versions
+    if(OpenCV_VERSION VERSION_LESS "3.0.0")
+        list(APPEND _OpenCV_REQUIRED_COMPONENTS contrib)
+        find_package(OpenCV COMPONENTS ${_OpenCV_REQUIRED_COMPONENTS} CONFIG)
+    endif()
+
     add_executable(opencv_demo example/opencv_demo.cc)
     target_link_libraries(opencv_demo apriltag ${OpenCV_LIBRARIES})
     set_target_properties(opencv_demo PROPERTIES CXX_STANDARD 11)

--- a/package.xml
+++ b/package.xml
@@ -15,8 +15,6 @@
   <url>https://april.eecs.umich.edu/software/apriltag.html</url>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <!-- Do not install numpy for Python2, so it won't build a Python3 wrapper when Python2 is ROS-default -->
-  <!--<build_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</build_depend>-->
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_depend>
 
   <!-- Specify test dependency on OpenCV such that examples are built on the test server-->


### PR DESCRIPTION
Noticed that the OpenCV demo wasn't configured despite OpenCV being installed since the `contrib` module wasn't found.