### PR TITLE
enable ASan for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ASAN "Use AddressSanitizer for debug builds to detect memory issues" OFF)
 
 if (ASAN)
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} \
+    set(ASAN_FLAGS "\
         -fsanitize=address \
         -fsanitize=bool \
         -fsanitize=bounds \
@@ -24,6 +24,8 @@ if (ASAN)
         -fsanitize=leak \
         -fsanitize=object-size \
     ")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ASAN_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ASAN_FLAGS}")
 endif()
 
 # Set a default build type if none was specified

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     }
 
     cout << "Enabling video capture" << endl;
-    
+
     TickMeter meter;
     meter.start();
 
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
         printf("Unable to add family to detector due to insufficient memory to allocate the tag-family decoder with the default maximum hamming value of 2. Try choosing an alternative tag family.\n");
         exit(-1);
     }
-    
+
     td->quad_decimate = getopt_get_double(getopt, "decimate");
     td->quad_sigma = getopt_get_double(getopt, "blur");
     td->nthreads = getopt_get_int(getopt, "threads");
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
 
     float frame_counter = 0.0f;
     meter.stop();
-    cout << "Detector " << famname << " initialized in " 
+    cout << "Detector " << famname << " initialized in "
         << std::fixed << std::setprecision(3) << meter.getTimeSec() << " seconds" << endl;
 #if CV_MAJOR_VERSION > 3
     cout << "  " << cap.get(CAP_PROP_FRAME_WIDTH ) << "x" <<

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
     getopt_t *getopt = getopt_create();
 
     getopt_add_bool(getopt, 'h', "help", 0, "Show this help");
+    getopt_add_int(getopt, 'c', "camera", "0", "camera ID");
     getopt_add_bool(getopt, 'd', "debug", 0, "Enable debugging output (slow)");
     getopt_add_bool(getopt, 'q', "quiet", 0, "Reduce output");
     getopt_add_string(getopt, 'f', "family", "tag36h11", "Tag family to use");
@@ -73,7 +74,7 @@ int main(int argc, char *argv[])
     meter.start();
 
     // Initialize camera
-    VideoCapture cap(0);
+    VideoCapture cap(getopt_get_int(getopt, "camera"));
     if (!cap.isOpened()) {
         cerr << "Couldn't open video capture device" << endl;
         return -1;


### PR DESCRIPTION
When looking into https://github.com/AprilRobotics/apriltag/issues/253 I noticed that the AddressSanitizer is not enabled for C++ code. This is only relevant for the `opencv_demo`.

This PR uses the same ASAN flags for C and C++ code and for Debug as well as Release builds. While at it, I fixed some of the whitespace issues and added an additional configuration flag `-c` to select the camera to use.

Regarding the actual memory leaks, there are some leaks in `libfontconfig.so`. But overall, this seems to be constant. No matter how long I let the `opencv_demo` run without showing an actual tag, ASan will report `SUMMARY: AddressSanitizer: 43736 byte(s) leaked in 812 allocation(s).`.

However, ASan reported some `division by zero` errors which may be related to https://github.com/AprilRobotics/apriltag/pull/213:
```
apriltag_math.h:73:37: runtime error: division by zero
apriltag_math.h:76:23: runtime error: division by zero
apriltag_math.h:79:14: runtime error: division by zero
apriltag.c:847:24: runtime error: division by zero
apriltag.c:847:37: runtime error: division by zero
apriltag.c:848:26: runtime error: division by zero
apriltag.c:849:26: runtime error: division by zero
apriltag.c:850:26: runtime error: division by zero
apriltag_math.h:41:17: runtime error: division by zero
apriltag_math.h:44:17: runtime error: division by zero
apriltag_math.h:64:14: runtime error: division by zero
apriltag_math.h:50:31: runtime error: division by zero
apriltag_math.h:67:23: runtime error: division by zero
apriltag_math.h:70:14: runtime error: division by zero
apriltag_quad_thresh.c:912:26: runtime error: division by zero
apriltag_quad_thresh.c:912:44: runtime error: division by zero
```