### PR TITLE
Split work up in gradient_clusters more finely

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1670,7 +1670,7 @@ zarray_t* gradient_clusters(apriltag_detector_t *td, image_u8_t* threshim, int w
     int nclustermap = 0.2*w*h;
 
     int sz = h - 1;
-    int chunksize = 1 + sz / td->nthreads;
+    int chunksize = 1 + sz / (APRILTAG_TASKS_PER_THREAD_TARGET * td->nthreads);
     struct cluster_task *tasks = malloc(sizeof(struct cluster_task)*(sz / chunksize + 1));
 
     int ntasks = 0;


### PR DESCRIPTION
In other chunks of work split into thread pools, the work is split up more finely than the number of CPUs.  This makes it so that if a thread gets behind (in a big.little architecture, this is expected, or in the case of preemption), the threads that are ahead can pick up the extra work.

gradient_clusters was missing this split.  This saved 5-10ms of processing time on my Rock Pi 4b and reduced the outliers.