### PR TITLE
Speed up cluster merge by batch copying arrays

### DIFF
--- a/common/zarray.h
+++ b/common/zarray.h
@@ -437,26 +437,27 @@ static inline int zarray_index_of(const zarray_t *za, const void *p)
     return -1;
 }
 
-
-
 /**
- * Add all elements from 'source' into 'dest'. el_size must be the same
- * for both lists
+ * Add elements from start up to and excluding end from 'source' into 'dest'.
+ * el_sz must be the same for both lists
  **/
-static inline void zarray_add_all(zarray_t * dest, const zarray_t * source)
+static inline void zarray_add_range(zarray_t *dest, const zarray_t *source, int start, int end)
 {
     assert(dest->el_sz == source->el_sz);
+    assert(dest != NULL);
+    assert(source != NULL);
+    assert(start >= 0);
+    assert(end <= source->size);
+    if (start == end) {
+        return;
+    }
+    assert(start < end);
 
-    // Don't allocate on stack because el_sz could be larger than ~8 MB
-    // stack size
-    char *tmp = (char*)calloc(1, dest->el_sz);
+    int count = end - start;
+    zarray_ensure_capacity(dest, dest->size + count);
 
-    for (int i = 0; i < zarray_size(source); i++) {
-        zarray_get(source, i, tmp);
-        zarray_add(dest, tmp);
-   }
-
-    free(tmp);
+    memcpy(&dest->data[dest->size*dest->el_sz], &source->data[source->el_sz*start], dest->el_sz*count);
+    dest->size += count;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
I was looking through the code and found that a lot of time was being spent on 'make clusters' so I did a quick look through why that is the case. I found the merge_clusters function to be inefficient, so I optimized it to do batch memcopies wherever possible.

This gives me a ~20% reduction in time spent for a large image.

## Before

<img width="827" alt="Screenshot 2023-06-15 at 14 33 47" src="https://github.com/AprilRobotics/apriltag/assets/97820/6157ae34-5929-49d7-a6a4-dd3bcf65a81a">

## After

<img width="827" alt="Screenshot 2023-06-15 at 14 33 56" src="https://github.com/AprilRobotics/apriltag/assets/97820/890b26f9-bda3-48fa-bd67-e52470d59fb9">
