### PR TITLE
change default decimation parameter for python wrapper

### DIFF
--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -86,7 +86,7 @@ apriltag_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     const char* family          = NULL;
     int         Nthreads        = 1;
     int         maxhamming      = 1;
-    float       decimate        = 1.0;
+    float       decimate        = 2.0;
     float       blur            = 0.0;
     bool        refine_edges    = true;
     bool        debug           = false;


### PR DESCRIPTION
I was stunned for a while when using Python wrapper, because the behavior was different from that of C.
Specifically, when the image is blurry and noisy (bad lighting & bad focus), and a tag is close enough so that it takes a good portion of an image, the Apriltag detection fails for Python wrapper, while the original C implementation manages to detect it nevertheless.
The problem was that the default decimation value was 2.0 for C, and 1.0 for Python wrapper.
As having different default behavior can be deceiving to many, and is counter-intuitive, I open this PR.

