### PR TITLE
Changed type to size_t for consistent type comparison

### DIFF
--- a/common/getopt.c
+++ b/common/getopt.c
@@ -241,7 +241,7 @@ int getopt_parse(getopt_t *gopt, int argc, char *argv[], int showErrors)
 
         if (!strncmp(tok,"-",1) && strncmp(tok,"--",2)) {
             size_t len = strlen(tok);
-            int pos;
+            size_t pos;
             for (pos = 1; pos < len; pos++) {
                 char sopt[2];
                 sopt[0] = tok[pos];

--- a/common/pam.c
+++ b/common/pam.c
@@ -64,7 +64,7 @@ pam_t *pam_create_from_file(const char *inpath)
             continue;
 
         size_t linelen = strlen(line);
-        for (int idx = 0; idx < linelen; idx++) {
+        for (size_t idx = 0; idx < linelen; idx++) {
             if (line[idx] == ' ') {
                 line[idx] = 0;
                 if (tok1) {

--- a/common/string_util.c
+++ b/common/string_util.c
@@ -647,7 +647,7 @@ char *str_replace(const char *haystack, const char *needle, const char *replacem
     size_t haystack_len = strlen(haystack);
     size_t needle_len = strlen(needle);
 
-    int pos = 0;
+    size_t pos = 0;
     while (pos < haystack_len) {
         if (needle_len > 0 && str_starts_with(&haystack[pos], needle)) {
             string_buffer_append_string(sb, replacement);


### PR DESCRIPTION
In getopt.c, the variable pos was of type int and this comparison to the len variable, which is of type size_t, presents a security vulnerability for my team's utilization of this repository as pos is of a different type than len. I changed the pos variable to be of type size_t to enable pos and len to be consistently compared in the for loop where "pos < len". Similarly, in string_util.c, pos and haystack_len are compared as inconsistent types so to address this security vulnerability, I changed pos to be of type size_t. In pam.c, I changed idx to be of type size_t to address the same security vulnerability as for the files above. 