### PR TITLE
fix compilation with WIN32_LEAN_AND_MEAN

### DIFF
--- a/common/time_util.h
+++ b/common/time_util.h
@@ -32,7 +32,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 #include <time.h>
 
 #ifdef _WIN32
-#include <windows.h>
+#include <Winsock2.h>
 typedef long long suseconds_t;
 #endif
 


### PR DESCRIPTION
This PR resolves #296. I changed `windows.h` header for `Winsock2.h`. This way the library still works even when used with `WIN32_LEAN_AND_MEAN` preprocessor definition.

I think even better solution would be to move function `gettimeofday` in `time_util.c` which is the only place where it is used. This way we can also move any required headers (either `windows.h`, `winsock.h` or `Winsock2.h`) from header file which would prevent any side effects to other libraries.

https://github.com/AprilRobotics/apriltag/blob/cc655ad6e3dadb19658276f7476dad5e92f05144/common/time_util.h#L41 