### PR TITLE
CMake install: Set .dll location to bin folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVers
 install(TARGETS ${PROJECT_NAME} EXPORT ${targets_export_name}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
 
 install(EXPORT ${targets_export_name}


### PR DESCRIPTION
When building apriltag as a shared library on Windows, the DLLs could be installed in the bin folder, where the variable PATH should be properly configured, resulting in no problems at runtime.

Reference: https://cmake.org/cmake/help/latest/command/install.html#signatures