### PR TITLE
fix incorrect C example #246

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Alternately you can use the AprilTag python bindings created by [duckietown](htt
         // Do stuff with detections here.
     }
     // Cleanup.
+    apriltag_detections_destroy(detections);
     tagStandard41h12_destroy(tf);
     apriltag_detector_destroy(td);
 


### PR DESCRIPTION
Add missing `apriltag_detections_destroy()` call. Fix #246