### PR TITLE
Rename missnamed err to mse.

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -904,10 +904,10 @@ int fit_quad(
         int i0 = indices[i];
         int i1 = indices[(i+1)&3];
 
-        double err;
-        fit_line(lfps, sz, i0, i1, lines[i], NULL, &err);
+        double mse;
+        fit_line(lfps, sz, i0, i1, lines[i], NULL, &mse);
 
-        if (err > td->qtp.max_line_fit_mse) {
+        if (mse > td->qtp.max_line_fit_mse) {
             res = 0;
             goto finish;
         }


### PR DESCRIPTION
It was being used as a mse, and passed into fit_line in the mse position.  Let's make the name match.