### PR TITLE
fix warnings

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         env:
           # ROS 1
-          - {ROS_DISTRO: kinetic}
-          - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
           # ROS 2
           - {ROS_DISTRO: humble}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ if (MSVC)
     add_compile_definitions("_CRT_SECURE_NO_WARNINGS")
 else()
     find_package(Threads REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads m)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
+endif()
+
+if (UNIX)
+    target_link_libraries(${PROJECT_NAME} PUBLIC m)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 3 VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 project(apriltag VERSION 3.3.0 LANGUAGES C CXX)
 
 if(POLICY CMP0077)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,15 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS  "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Werror)
+    # add_compile_options(-Wpedantic)
+    add_compile_options(-Wno-shift-negative-value)
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "AppleClang")
+        add_link_options("-Wl,-z,relro,-z,now,-z,defs")
+    endif()
+endif()
+
 aux_source_directory(common COMMON_SRC)
 set(APRILTAG_SRCS apriltag.c apriltag_pose.c apriltag_quad_thresh.c)
 

--- a/apriltag.c
+++ b/apriltag.c
@@ -1341,8 +1341,7 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
                 int k = (j + 1) & 3;
                 image_u8x3_draw_line(out,
                                      det->p[j][0], det->p[j][1], det->p[k][0], det->p[k][1],
-                                     (uint8_t[]) { rgb[0], rgb[1], rgb[2] },
-                                     1);
+                                     (uint8_t[]) { rgb[0], rgb[1], rgb[2] });
             }
         }
 

--- a/apriltag.c
+++ b/apriltag.c
@@ -231,7 +231,7 @@ static void quick_decode_init(apriltag_family_t *family, int maxhamming)
 
     errno = 0;
 
-    for (int i = 0; i < family->ncodes; i++) {
+    for (uint32_t i = 0; i < family->ncodes; i++) {
         uint64_t code = family->codes[i];
 
         // add exact code (hamming = 0)
@@ -624,7 +624,7 @@ static float quad_decode(apriltag_detector_t* td, apriltag_family_t *family, ima
     graymodel_init(&whitemodel);
     graymodel_init(&blackmodel);
 
-    for (int pattern_idx = 0; pattern_idx < sizeof(patterns)/(5*sizeof(float)); pattern_idx ++) {
+    for (long unsigned int pattern_idx = 0; pattern_idx < sizeof(patterns)/(5*sizeof(float)); pattern_idx ++) {
         float *pattern = &patterns[pattern_idx * 5];
 
         int is_white = pattern[4];
@@ -685,7 +685,7 @@ static float quad_decode(apriltag_detector_t* td, apriltag_family_t *family, ima
     double *values = calloc(family->total_width*family->total_width, sizeof(double));
 
     int min_coord = (family->width_at_border - family->total_width)/2;
-    for (int i = 0; i < family->nbits; i++) {
+    for (uint32_t i = 0; i < family->nbits; i++) {
         int bity = family->bit_y[i];
         int bitx = family->bit_x[i];
 
@@ -718,7 +718,7 @@ static float quad_decode(apriltag_detector_t* td, apriltag_family_t *family, ima
     sharpen(td, values, family->total_width);
 
     uint64_t rcode = 0;
-    for (int i = 0; i < family->nbits; i++) {
+    for (uint32_t i = 0; i < family->nbits; i++) {
         int bity = family->bit_y[i];
         int bitx = family->bit_x[i];
         rcode = (rcode << 1);
@@ -1424,10 +1424,10 @@ void apriltag_detections_destroy(zarray_t *detections)
     zarray_destroy(detections);
 }
 
-image_u8_t *apriltag_to_image(apriltag_family_t *fam, int idx)
+image_u8_t *apriltag_to_image(apriltag_family_t *fam, uint32_t idx)
 {
     assert(fam != NULL);
-    assert(idx >= 0 && idx < fam->ncodes);
+    assert(idx < fam->ncodes);
 
     uint64_t code = fam->codes[idx];
 
@@ -1444,7 +1444,7 @@ image_u8_t *apriltag_to_image(apriltag_family_t *fam, int idx)
     }
 
     int border_start = (fam->total_width - fam->width_at_border)/2;
-    for (int i = 0; i < fam->nbits; i++) {
+    for (uint32_t i = 0; i < fam->nbits; i++) {
         if (code & (APRILTAG_U64_ONE << (fam->nbits - i - 1))) {
             im->buf[(fam->bit_y[i] + border_start)*im->stride + fam->bit_x[i] + border_start] = 255;
         }

--- a/apriltag.h
+++ b/apriltag.h
@@ -269,7 +269,7 @@ void apriltag_detections_destroy(zarray_t *detections);
 
 // Renders the apriltag.
 // Caller is responsible for calling image_u8_destroy on the image
-image_u8_t *apriltag_to_image(apriltag_family_t *fam, int idx);
+image_u8_t *apriltag_to_image(apriltag_family_t *fam, uint32_t idx);
 
 #ifdef __cplusplus
 }

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1891,7 +1891,7 @@ zarray_t *apriltag_quad_thresh(apriltag_detector_t *td, image_u8_t *im)
             for (int x = 0; x < w; x++) {
                 uint32_t v = unionfind_get_representative(uf, y*w+x);
 
-                if (unionfind_get_set_size(uf, v) < td->qtp.min_cluster_pixels)
+                if ((int)unionfind_get_set_size(uf, v) < td->qtp.min_cluster_pixels)
                     continue;
 
                 uint32_t color = colors[v];

--- a/common/getopt.c
+++ b/common/getopt.c
@@ -176,7 +176,7 @@ int getopt_parse(getopt_t *gopt, int argc, char *argv[], int showErrors)
     }
 
     // now loop over the elements and evaluate the arguments
-    unsigned int i = 0;
+    int i = 0;
 
     char *tok = NULL;
 
@@ -499,7 +499,7 @@ char * getopt_get_usage(getopt_t *gopt)
     int longwidth=12;
     int valuewidth=10;
 
-    for (unsigned int i = 0; i < zarray_size(gopt->options); i++) {
+    for (int i = 0; i < zarray_size(gopt->options); i++) {
         getopt_option_t *goo = NULL;
         zarray_get(gopt->options, i, &goo);
 
@@ -512,7 +512,7 @@ char * getopt_get_usage(getopt_t *gopt)
             valuewidth = max(valuewidth, (int) strlen(goo->svalue));
     }
 
-    for (unsigned int i = 0; i < zarray_size(gopt->options); i++) {
+    for (int i = 0; i < zarray_size(gopt->options); i++) {
         getopt_option_t *goo = NULL;
         zarray_get(gopt->options, i, &goo);
 

--- a/common/homography.c
+++ b/common/homography.c
@@ -357,7 +357,7 @@ matd_t *homography_to_pose(const matd_t *H, double fx, double fy, double cx, dou
 // [ 0  0  C  D ]
 // [ 0  0 -1  0 ]
 
-matd_t *homography_to_model_view(const matd_t *H, double F, double G, double A, double B, double C, double D)
+matd_t *homography_to_model_view(const matd_t *H, double F, double G, double A, double B)
 {
     // Note that every variable that we compute is proportional to the scale factor of H.
     double R20 = -MATD_EL(H, 2, 0);

--- a/common/homography.h
+++ b/common/homography.h
@@ -176,7 +176,7 @@ matd_t *homography_to_pose(const matd_t *H, double fx, double fy, double cx, dou
 // [ 0  0  C  D ]
 // [ 0  0 -1  0 ]
 
-matd_t *homography_to_model_view(const matd_t *H, double F, double G, double A, double B, double C, double D);
+matd_t *homography_to_model_view(const matd_t *H, double F, double G, double A, double B);
 
 #ifdef __cplusplus
 }

--- a/common/image_u8.c
+++ b/common/image_u8.c
@@ -211,7 +211,7 @@ int image_u8_write_pnm(const image_u8_t *im, const char *path)
     fprintf(f, "P5\n%d %d\n255\n", im->width, im->height);
 
     for (int y = 0; y < im->height; y++) {
-        if (im->width != fwrite(&im->buf[y*im->stride], 1, im->width, f)) {
+        if (im->width != (int32_t)fwrite(&im->buf[y*im->stride], 1, im->width, f)) {
             res = -2;
             goto finish;
         }

--- a/common/image_u8x3.c
+++ b/common/image_u8x3.c
@@ -147,7 +147,7 @@ int image_u8x3_write_pnm(const image_u8x3_t *im, const char *path)
 
     // Only outputs to RGB
     fprintf(f, "P6\n%d %d\n255\n", im->width, im->height);
-    int linesz = im->width * 3;
+    size_t linesz = im->width * 3;
     for (int y = 0; y < im->height; y++) {
         if (linesz != fwrite(&im->buf[y*im->stride], 1, linesz, f)) {
             res = -1;

--- a/common/image_u8x3.c
+++ b/common/image_u8x3.c
@@ -163,7 +163,7 @@ finish:
 }
 
 // only width 1 supported
-void image_u8x3_draw_line(image_u8x3_t *im, float x0, float y0, float x1, float y1, uint8_t rgb[3], int width)
+void image_u8x3_draw_line(image_u8x3_t *im, float x0, float y0, float x1, float y1, uint8_t rgb[3])
 {
     double dist = sqrtf((y1-y0)*(y1-y0) + (x1-x0)*(x1-x0));
     double delta = 0.5 / dist;

--- a/common/image_u8x3.h
+++ b/common/image_u8x3.h
@@ -57,7 +57,7 @@ void image_u8x3_destroy(image_u8x3_t *im);
 int image_u8x3_write_pnm(const image_u8x3_t *im, const char *path);
 
 // only width 1 supported
-void image_u8x3_draw_line(image_u8x3_t *im, float x0, float y0, float x1, float y1, uint8_t rgb[3], int width);
+void image_u8x3_draw_line(image_u8x3_t *im, float x0, float y0, float x1, float y1, uint8_t rgb[3]);
 
 #ifdef __cplusplus
 }

--- a/common/matd.c
+++ b/common/matd.c
@@ -872,6 +872,8 @@ double matd_vec_dist_n(const matd_t *a, const matd_t *b, int n)
     int lenb = b->nrows*b->ncols;
 
     assert(n <= lena && n <= lenb);
+    (void)lena;
+    (void)lenb;
 
     double mag = 0.0;
     for (int i = 0; i < n; i++)
@@ -906,6 +908,7 @@ double matd_vec_dot_product(const matd_t *a, const matd_t *b)
     int adim = a->ncols*a->nrows;
     int bdim = b->ncols*b->nrows;
     assert(adim == bdim);
+    (void)bdim;
 
     double acc = 0;
     for (int i = 0; i < adim; i++) {

--- a/common/matd.c
+++ b/common/matd.c
@@ -105,20 +105,18 @@ matd_t *matd_identity(int dim)
 }
 
 // row and col are zero-based
-TYPE matd_get(const matd_t *m, int row, int col)
+TYPE matd_get(const matd_t *m, unsigned int row, unsigned int col)
 {
     assert(m != NULL);
     assert(!matd_is_scalar(m));
-    assert(row >= 0);
     assert(row < m->nrows);
-    assert(col >= 0);
     assert(col < m->ncols);
 
     return MATD_EL(m, row, col);
 }
 
 // row and col are zero-based
-void matd_put(matd_t *m, int row, int col, TYPE value)
+void matd_put(matd_t *m, unsigned int row, unsigned int col, TYPE value)
 {
     assert(m != NULL);
 
@@ -127,9 +125,7 @@ void matd_put(matd_t *m, int row, int col, TYPE value)
         return;
     }
 
-    assert(row >= 0);
     assert(row < m->nrows);
-    assert(col >= 0);
     assert(col < m->ncols);
 
     MATD_EL(m, row, col) = value;
@@ -164,12 +160,12 @@ matd_t *matd_copy(const matd_t *m)
     return x;
 }
 
-matd_t *matd_select(const matd_t * a, int r0, int r1, int c0, int c1)
+matd_t *matd_select(const matd_t * a, unsigned int r0, int r1, unsigned int c0, int c1)
 {
     assert(a != NULL);
 
-    assert(r0 >= 0 && r0 < a->nrows);
-    assert(c0 >= 0 && c0 < a->ncols);
+    assert(r0 < a->nrows);
+    assert(c0 < a->ncols);
 
     int nrows = r1 - r0 + 1;
     int ncols = c1 - c0 + 1;
@@ -192,8 +188,8 @@ void matd_print(const matd_t *m, const char *fmt)
         printf(fmt, MATD_EL(m, 0, 0));
         printf("\n");
     } else {
-        for (int i = 0; i < m->nrows; i++) {
-            for (int j = 0; j < m->ncols; j++) {
+        for (unsigned int i = 0; i < m->nrows; i++) {
+            for (unsigned int j = 0; j < m->ncols; j++) {
                 printf(fmt, MATD_EL(m, i, j));
             }
             printf("\n");
@@ -210,8 +206,8 @@ void matd_print_transpose(const matd_t *m, const char *fmt)
         printf(fmt, MATD_EL(m, 0, 0));
         printf("\n");
     } else {
-        for (int j = 0; j < m->ncols; j++) {
-            for (int i = 0; i < m->nrows; i++) {
+        for (unsigned int j = 0; j < m->ncols; j++) {
+            for (unsigned int i = 0; i < m->nrows; i++) {
                 printf(fmt, MATD_EL(m, i, j));
             }
             printf("\n");
@@ -241,10 +237,10 @@ matd_t *matd_multiply(const matd_t *a, const matd_t *b)
     assert(a->ncols == b->nrows);
     matd_t *m = matd_create(a->nrows, b->ncols);
 
-    for (int i = 0; i < m->nrows; i++) {
-        for (int j = 0; j < m->ncols; j++) {
+    for (unsigned int i = 0; i < m->nrows; i++) {
+        for (unsigned int j = 0; j < m->ncols; j++) {
             TYPE acc = 0;
-            for (int k = 0; k < a->ncols; k++) {
+            for (unsigned int k = 0; k < a->ncols; k++) {
                 acc += MATD_EL(a, i, k) * MATD_EL(b, k, j);
             }
             MATD_EL(m, i, j) = acc;
@@ -263,8 +259,8 @@ matd_t *matd_scale(const matd_t *a, double s)
 
     matd_t *m = matd_create(a->nrows, a->ncols);
 
-    for (int i = 0; i < m->nrows; i++) {
-        for (int j = 0; j < m->ncols; j++) {
+    for (unsigned int i = 0; i < m->nrows; i++) {
+        for (unsigned int j = 0; j < m->ncols; j++) {
             MATD_EL(m, i, j) = s * MATD_EL(a, i, j);
         }
     }
@@ -281,8 +277,8 @@ void matd_scale_inplace(matd_t *a, double s)
         return;
     }
 
-    for (int i = 0; i < a->nrows; i++) {
-        for (int j = 0; j < a->ncols; j++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
+        for (unsigned int j = 0; j < a->ncols; j++) {
             MATD_EL(a, i, j) *= s;
         }
     }
@@ -300,8 +296,8 @@ matd_t *matd_add(const matd_t *a, const matd_t *b)
 
     matd_t *m = matd_create(a->nrows, a->ncols);
 
-    for (int i = 0; i < m->nrows; i++) {
-        for (int j = 0; j < m->ncols; j++) {
+    for (unsigned int i = 0; i < m->nrows; i++) {
+        for (unsigned int j = 0; j < m->ncols; j++) {
             MATD_EL(m, i, j) = MATD_EL(a, i, j) + MATD_EL(b, i, j);
         }
     }
@@ -321,8 +317,8 @@ void matd_add_inplace(matd_t *a, const matd_t *b)
         return;
     }
 
-    for (int i = 0; i < a->nrows; i++) {
-        for (int j = 0; j < a->ncols; j++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
+        for (unsigned int j = 0; j < a->ncols; j++) {
             MATD_EL(a, i, j) += MATD_EL(b, i, j);
         }
     }
@@ -341,8 +337,8 @@ matd_t *matd_subtract(const matd_t *a, const matd_t *b)
 
     matd_t *m = matd_create(a->nrows, a->ncols);
 
-    for (int i = 0; i < m->nrows; i++) {
-        for (int j = 0; j < m->ncols; j++) {
+    for (unsigned int i = 0; i < m->nrows; i++) {
+        for (unsigned int j = 0; j < m->ncols; j++) {
             MATD_EL(m, i, j) = MATD_EL(a, i, j) - MATD_EL(b, i, j);
         }
     }
@@ -362,8 +358,8 @@ void matd_subtract_inplace(matd_t *a, const matd_t *b)
         return;
     }
 
-    for (int i = 0; i < a->nrows; i++) {
-        for (int j = 0; j < a->ncols; j++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
+        for (unsigned int j = 0; j < a->ncols; j++) {
             MATD_EL(a, i, j) -= MATD_EL(b, i, j);
         }
     }
@@ -379,8 +375,8 @@ matd_t *matd_transpose(const matd_t *a)
 
     matd_t *m = matd_create(a->ncols, a->nrows);
 
-    for (int i = 0; i < a->nrows; i++) {
-        for (int j = 0; j < a->ncols; j++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
+        for (unsigned int j = 0; j < a->ncols; j++) {
             MATD_EL(m, j, i) = MATD_EL(a, i, j);
         }
     }
@@ -398,7 +394,7 @@ double matd_det_general(const matd_t *a)
     // The determinants of the L and U matrices are the products of
     // their respective diagonal elements
     double detL = 1; double detU = 1;
-    for (int i = 0; i < a->nrows; i++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
         detL *= matd_get(L, i, i);
         detU *= matd_get(U, i, i);
     }
@@ -958,8 +954,8 @@ TYPE matd_err_inf(const matd_t *a, const matd_t *b)
 
     TYPE maxf = 0;
 
-    for (int i = 0; i < a->nrows; i++) {
-        for (int j = 0; j < a->ncols; j++) {
+    for (unsigned int i = 0; i < a->nrows; i++) {
+        for (unsigned int j = 0; j < a->ncols; j++) {
             TYPE av = MATD_EL(a, i, j);
             TYPE bv = MATD_EL(b, i, j);
 
@@ -1003,7 +999,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     // RS: cumulative right-handed transformations.
     matd_t *RS = matd_identity(A->ncols);
 
-    for (int hhidx = 0; hhidx < A->nrows; hhidx++)  {
+    for (unsigned int hhidx = 0; hhidx < A->nrows; hhidx++)  {
 
         if (hhidx < A->ncols) {
             // We construct the normal of the reflection plane: let u
@@ -1063,7 +1059,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             // LS = matd_op("F*M", LS, Q);
             // Implementation: take each row of LS, compute dot product with n,
             // subtract n (scaled by dot product) from it.
-            for (int i = 0; i < LS->nrows; i++) {
+            for (unsigned int i = 0; i < LS->nrows; i++) {
                 double dot = 0;
                 for (int j = 0; j < vlen; j++)
                     dot += MATD_EL(LS, i, hhidx+j) * v[j];
@@ -1072,7 +1068,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             }
 
             //  B = matd_op("M*F", Q, B); // should be Q', but Q is symmetric.
-            for (int i = 0; i < B->ncols; i++) {
+            for (unsigned int i = 0; i < B->ncols; i++) {
                 double dot = 0;
                 for (int j = 0; j < vlen; j++)
                     dot += MATD_EL(B, hhidx+j, i) * v[j];
@@ -1121,7 +1117,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             //       MATD_EL(Q, i+1+hhidx, j+1+hhidx) -= 2*v[i]*v[j];
 
             //  RS = matd_op("F*M", RS, Q);
-            for (int i = 0; i < RS->nrows; i++) {
+            for (unsigned int i = 0; i < RS->nrows; i++) {
                 double dot = 0;
                 for (int j = 0; j < vlen; j++)
                     dot += MATD_EL(RS, i, hhidx+1+j) * v[j];
@@ -1130,7 +1126,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             }
 
             //   B = matd_op("F*M", B, Q); // should be Q', but Q is symmetric.
-            for (int i = 0; i < B->nrows; i++) {
+            for (unsigned int i = 0; i < B->nrows; i++) {
                 double dot = 0;
                 for (int j = 0; j < vlen; j++)
                     dot += MATD_EL(B, i, hhidx+1+j) * v[j];
@@ -1159,11 +1155,11 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
 
     // for each of the first B->ncols rows, which index has the
     // maximum absolute value? (used by method 1)
-    int *maxrowidx = malloc(sizeof(int)*B->ncols);
-    int lastmaxi, lastmaxj;
+    unsigned int *maxrowidx = malloc(sizeof(int)*B->ncols);
+    unsigned int lastmaxi, lastmaxj;
 
     if (find_max_method == 1) {
-        for (int i = 2; i < B->ncols; i++)
+        for (unsigned int i = 2; i < B->ncols; i++)
             maxrowidx[i] = max_idx(B, i, B->ncols);
 
         // note that we started the array at 2. That's because by setting
@@ -1196,7 +1192,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             // modified. Update maxrowidx accordingly.
 
             // now, EVERY row also had columns lastmaxi and lastmaxj modified.
-            for (int rowi = 0; rowi < B->ncols; rowi++) {
+            for (unsigned int rowi = 0; rowi < B->ncols; rowi++) {
 
                 // the magnitude of the largest off-diagonal element
                 // in this row.
@@ -1269,8 +1265,8 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             maxv = -1;
 
             // only search top "square" portion
-            for (int i = 0; i < B->ncols; i++) {
-                for (int j = 0; j < B->ncols; j++) {
+            for (unsigned int i = 0; i < B->ncols; i++) {
+                for (unsigned int j = 0; j < B->ncols; j++) {
                     if (i == j)
                         continue;
 
@@ -1335,7 +1331,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
 */
 
             //  LS = matd_op("F*M", LS, QL);
-            for (int i = 0; i < LS->nrows; i++) {
+            for (unsigned int i = 0; i < LS->nrows; i++) {
                 double vi = MATD_EL(LS, i, maxi);
                 double vj = MATD_EL(LS, i, maxj);
 
@@ -1344,7 +1340,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             }
 
             //  RS = matd_op("F*M", RS, QR); // remember we'll transpose RS.
-            for (int i = 0; i < RS->nrows; i++) {
+            for (unsigned int i = 0; i < RS->nrows; i++) {
                 double vi = MATD_EL(RS, i, maxi);
                 double vj = MATD_EL(RS, i, maxj);
 
@@ -1354,7 +1350,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
 
             // B = matd_op("M'*F*M", QL, B, QR);
             // The QL matrix mixes rows of B.
-            for (int i = 0; i < B->ncols; i++) {
+            for (unsigned int i = 0; i < B->ncols; i++) {
                 double vi = MATD_EL(B, maxi, i);
                 double vj = MATD_EL(B, maxj, i);
 
@@ -1363,7 +1359,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
             }
 
             // The QR matrix mixes columns of B.
-            for (int i = 0; i < B->nrows; i++) {
+            for (unsigned int i = 0; i < B->nrows; i++) {
                 double vi = MATD_EL(B, i, maxi);
                 double vj = MATD_EL(B, i, maxj);
 
@@ -1386,7 +1382,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     // U/LS.
     int *idxs = malloc(sizeof(int)*A->ncols);
     double *vals = malloc(sizeof(double)*A->ncols);
-    for (int i = 0; i < A->ncols; i++) {
+    for (unsigned int i = 0; i < A->ncols; i++) {
         idxs[i] = i;
         vals[i] = MATD_EL(B, i, i);
     }
@@ -1396,7 +1392,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     do {
         changed = 0;
 
-        for (int i = 0; i + 1 < A->ncols; i++) {
+        for (unsigned int i = 0; i + 1 < A->ncols; i++) {
             if (fabs(vals[i+1]) > fabs(vals[i])) {
                 int tmpi = idxs[i];
                 idxs[i] = idxs[i+1];
@@ -1414,7 +1410,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     matd_t *LP = matd_identity(A->nrows);
     matd_t *RP = matd_identity(A->ncols);
 
-    for (int i = 0; i < A->ncols; i++) {
+    for (unsigned int i = 0; i < A->ncols; i++) {
         MATD_EL(LP, idxs[i], idxs[i]) = 0; // undo the identity above
         MATD_EL(RP, idxs[i], idxs[i]) = 0;
 
@@ -1442,8 +1438,8 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
 
     // make B exactly diagonal
 
-    for (int i = 0; i < B->nrows; i++) {
-        for (int j = 0; j < B->ncols; j++) {
+    for (unsigned int i = 0; i < B->nrows; i++) {
+        for (unsigned int j = 0; j < B->ncols; j++) {
             if (i != j)
                 MATD_EL(B, i, j) = 0;
         }
@@ -1520,11 +1516,11 @@ matd_plu_t *matd_plu(const matd_t *a)
 
     matd_plu_t *mlu = calloc(1, sizeof(matd_plu_t));
 
-    for (int i = 0; i < a->nrows; i++)
+    for (unsigned int i = 0; i < a->nrows; i++)
         piv[i] = i;
 
-    for (int j = 0; j < a->ncols; j++) {
-        for (int i = 0; i < a->nrows; i++) {
+    for (unsigned int j = 0; j < a->ncols; j++) {
+        for (unsigned int i = 0; i < a->nrows; i++) {
             int kmax = i < j ? i : j; // min(i,j)
 
             // compute dot product of row i with column j (up through element kmax)
@@ -1536,9 +1532,9 @@ matd_plu_t *matd_plu(const matd_t *a)
         }
 
         // find pivot and exchange if necessary.
-        int p = j;
+        unsigned int p = j;
         if (1) {
-            for (int i = j+1; i < lu->nrows; i++) {
+            for (unsigned int i = j+1; i < lu->nrows; i++) {
                 if (fabs(MATD_EL(lu,i,j)) > fabs(MATD_EL(lu, p, j))) {
                     p = i;
                 }
@@ -1577,7 +1573,7 @@ matd_plu_t *matd_plu(const matd_t *a)
 
         if (j < lu->ncols && j < lu->nrows && LUjj != 0) {
             LUjj = 1.0 / LUjj;
-            for (int i = j+1; i < lu->nrows; i++)
+            for (unsigned int i = j+1; i < lu->nrows; i++)
                 MATD_EL(lu, i, j) *= LUjj;
         }
     }
@@ -1603,7 +1599,7 @@ double matd_plu_det(const matd_plu_t *mlu)
     double det = mlu->pivsign;
 
     if (lu->nrows == lu->ncols) {
-        for (int i = 0; i < lu->ncols; i++)
+        for (unsigned int i = 0; i < lu->ncols; i++)
             det *= MATD_EL(lu, i, i);
     }
 
@@ -1615,7 +1611,7 @@ matd_t *matd_plu_p(const matd_plu_t *mlu)
     matd_t *lu = mlu->lu;
     matd_t *P = matd_create(lu->nrows, lu->nrows);
 
-    for (int i = 0; i < lu->nrows; i++) {
+    for (unsigned int i = 0; i < lu->nrows; i++) {
         MATD_EL(P, mlu->piv[i], i) = 1;
     }
 
@@ -1627,10 +1623,10 @@ matd_t *matd_plu_l(const matd_plu_t *mlu)
     matd_t *lu = mlu->lu;
 
     matd_t *L = matd_create(lu->nrows, lu->ncols);
-    for (int i = 0; i < lu->nrows; i++) {
+    for (unsigned int i = 0; i < lu->nrows; i++) {
         MATD_EL(L, i, i) = 1;
 
-        for (int j = 0; j < i; j++) {
+        for (unsigned int j = 0; j < i; j++) {
             MATD_EL(L, i, j) = MATD_EL(lu, i, j);
         }
     }
@@ -1643,8 +1639,8 @@ matd_t *matd_plu_u(const matd_plu_t *mlu)
     matd_t *lu = mlu->lu;
 
     matd_t *U = matd_create(lu->ncols, lu->ncols);
-    for (int i = 0; i < lu->ncols; i++) {
-        for (int j = 0; j < lu->ncols; j++) {
+    for (unsigned int i = 0; i < lu->ncols; i++) {
+        for (unsigned int j = 0; j < lu->ncols; j++) {
             if (i <= j)
                 MATD_EL(U, i, j) = MATD_EL(lu, i, j);
         }
@@ -1662,14 +1658,14 @@ matd_t *matd_plu_solve(const matd_plu_t *mlu, const matd_t *b)
     matd_t *x = matd_copy(b);
 
     // permute right hand side
-    for (int i = 0; i < mlu->lu->nrows; i++)
+    for (unsigned int i = 0; i < mlu->lu->nrows; i++)
         memcpy(&MATD_EL(x, i, 0), &MATD_EL(b, mlu->piv[i], 0), sizeof(TYPE) * b->ncols);
 
     // solve Ly = b
-    for (int k = 0; k < mlu->lu->nrows; k++) {
-        for (int i = k+1; i < mlu->lu->nrows; i++) {
+    for (unsigned int k = 0; k < mlu->lu->nrows; k++) {
+        for (unsigned int i = k+1; i < mlu->lu->nrows; i++) {
             double LUik = -MATD_EL(mlu->lu, i, k);
-            for (int t = 0; t < b->ncols; t++)
+            for (unsigned int t = 0; t < b->ncols; t++)
                 MATD_EL(x, i, t) += MATD_EL(x, k, t) * LUik;
         }
     }
@@ -1677,12 +1673,12 @@ matd_t *matd_plu_solve(const matd_plu_t *mlu, const matd_t *b)
     // solve Ux = y
     for (int k = mlu->lu->ncols-1; k >= 0; k--) {
         double LUkk = 1.0 / MATD_EL(mlu->lu, k, k);
-        for (int t = 0; t < b->ncols; t++)
+        for (unsigned int t = 0; t < b->ncols; t++)
             MATD_EL(x, k, t) *= LUkk;
 
         for (int i = 0; i < k; i++) {
             double LUik = -MATD_EL(mlu->lu, i, k);
-            for (int t = 0; t < b->ncols; t++)
+            for (unsigned int t = 0; t < b->ncols; t++)
                 MATD_EL(x, i, t) += MATD_EL(x, k, t) *LUik;
         }
     }
@@ -1910,7 +1906,7 @@ void matd_ltransposetriangle_solve(matd_t *u, const TYPE *b, TYPE *x)
     for (int i = 0; i < n; i++) {
         x[i] /= MATD_EL(u, i, i);
 
-        for (int j = i+1; j < u->ncols; j++) {
+        for (unsigned int j = i+1; j < u->ncols; j++) {
             x[j] -= x[i] * MATD_EL(u, i, j);
         }
     }
@@ -1940,7 +1936,7 @@ void matd_utriangle_solve(matd_t *u, const TYPE *b, TYPE *x)
 
         double diag = MATD_EL(u, i, i);
 
-        for (int j = i+1; j < u->ncols; j++)
+        for (unsigned int j = i+1; j < u->ncols; j++)
             bi -= MATD_EL(u, i, j)*x[j];
 
         x[i] = bi / diag;
@@ -1957,17 +1953,17 @@ matd_t *matd_chol_solve(const matd_chol_t *chol, const matd_t *b)
 
     // solve Ly = b ==> (U')y = b
 
-    for (int i = 0; i < u->nrows; i++) {
-        for (int j = 0; j < i; j++) {
+    for (unsigned int i = 0; i < u->nrows; i++) {
+        for (unsigned int j = 0; j < i; j++) {
             // b[i] -= L[i,j]*x[j]... replicated across columns of b
             //   ==> i.e., ==>
             // b[i,k] -= L[i,j]*x[j,k]
-            for (int k = 0; k < b->ncols; k++) {
+            for (unsigned int k = 0; k < b->ncols; k++) {
                 MATD_EL(x, i, k) -= MATD_EL(u, j, i)*MATD_EL(x, j, k);
             }
         }
         // x[i] = b[i] / L[i,i]
-        for (int k = 0; k < b->ncols; k++) {
+        for (unsigned int k = 0; k < b->ncols; k++) {
             MATD_EL(x, i, k) /= MATD_EL(u, i, i);
         }
     }
@@ -1975,12 +1971,12 @@ matd_t *matd_chol_solve(const matd_chol_t *chol, const matd_t *b)
     // solve Ux = y
     for (int k = u->ncols-1; k >= 0; k--) {
         double LUkk = 1.0 / MATD_EL(u, k, k);
-        for (int t = 0; t < b->ncols; t++)
+        for (unsigned int t = 0; t < b->ncols; t++)
             MATD_EL(x, k, t) *= LUkk;
 
         for (int i = 0; i < k; i++) {
             double LUik = -MATD_EL(u, i, k);
-            for (int t = 0; t < b->ncols; t++)
+            for (unsigned int t = 0; t < b->ncols; t++)
                 MATD_EL(x, i, t) += MATD_EL(x, k, t) *LUik;
         }
     }
@@ -2016,8 +2012,8 @@ matd_t *matd_chol_inverse(matd_t *a)
 double matd_max(matd_t *m)
 {
     double d = -DBL_MAX;
-    for(int x=0; x<m->nrows; x++) {
-        for(int y=0; y<m->ncols; y++) {
+    for(unsigned int x=0; x<m->nrows; x++) {
+        for(unsigned int y=0; y<m->ncols; y++) {
             if(MATD_EL(m, x, y) > d)
                 d = MATD_EL(m, x, y);
         }

--- a/common/matd.h
+++ b/common/matd.h
@@ -113,13 +113,13 @@ matd_t *matd_create_scalar(double v);
  * Retrieves the cell value for matrix 'm' at the given zero-based row and column index.
  * Performs more thorough validation checking than MATD_EL().
  */
-double matd_get(const matd_t *m, int row, int col);
+double matd_get(const matd_t *m, unsigned int row, unsigned int col);
 
 /**
  * Assigns the given value to the matrix cell at the given zero-based row and
  * column index. Performs more thorough validation checking than MATD_EL().
  */
-void matd_put(matd_t *m, int row, int col, double value);
+void matd_put(matd_t *m, unsigned int row, unsigned int col, double value);
 
 /**
  * Retrieves the scalar value of the given element ('m' must be a scalar).
@@ -147,7 +147,7 @@ matd_t *matd_copy(const matd_t *m);
  * beyond the number of rows/columns of 'a'. It is the caller's  responsibility to
  * call matd_destroy() on the returned matrix.
  */
-matd_t *matd_select(const matd_t *a, int r0, int r1, int c0, int c1);
+matd_t *matd_select(const matd_t *a, unsigned int r0, int r1, unsigned int c0, int c1);
 
 /**
  * Prints the supplied matrix 'm' to standard output by applying the supplied

--- a/common/pam.c
+++ b/common/pam.c
@@ -181,7 +181,7 @@ int pam_write_file(pam_t *pam, const char *outpath)
 
     fprintf(f, "P7\nWIDTH %d\nHEIGHT %d\nDEPTH %d\nMAXVAL %d\nTUPLTYPE %s\nENDHDR\n",
             pam->width, pam->height, pam->depth, pam->maxval, tupl);
-    int len = pam->width * pam->height * pam->depth;
+    size_t len = pam->width * pam->height * pam->depth;
     if (len != fwrite(pam->data, 1, len, f)) {
         fclose(f);
         return -2;

--- a/common/pam.h
+++ b/common/pam.h
@@ -40,7 +40,7 @@ struct pam
     int depth; // bytes per pixel
     int maxval; // maximum value per channel, e.g. 255 for 8bpp
 
-    int datalen; // in bytes
+    size_t datalen; // in bytes
     uint8_t *data;
 };
 

--- a/common/pjpeg.c
+++ b/common/pjpeg.c
@@ -864,6 +864,7 @@ pjpeg_t *pjpeg_create_from_buffer(uint8_t *buf, int buflen, uint32_t flags, int 
         pjd.inlen = sizeof(mjpeg_dht);
         int result = pjpeg_decode_buffer(&pjd);
         assert(result == 0);
+        (void)result;
     }
 
     pjd.in = buf;

--- a/common/pjpeg.c
+++ b/common/pjpeg.c
@@ -423,7 +423,7 @@ static int pjpeg_decode_buffer(struct pjpeg_decode_state *pjd)
                             if (code_pos + ncodes > 0xffff)
                                 return PJPEG_ERR_DHT;
 
-                            for (int ci = 0; ci < ncodes; ci++) {
+                            for (unsigned int ci = 0; ci < ncodes; ci++) {
                                 pjd->huff_codes[htidx][code_pos].nbits = nbits;
                                 pjd->huff_codes[htidx][code_pos].code = code;
                                 code_pos++;
@@ -753,8 +753,8 @@ image_u8x3_t *pjpeg_to_u8x3_baseline(pjpeg_t *pj)
 
     if (Cr_factor_y == 1 && Cr_factor_x == 1 && Cb_factor_y == 1 && Cb_factor_x == 1) {
 
-        for (int y = 0; y < pj->height; y++) {
-            for (int x = 0; x < pj->width; x++) {
+        for (uint32_t y = 0; y < pj->height; y++) {
+            for (uint32_t x = 0; x < pj->width; x++) {
                 int32_t y_val  = Y->data[y*Y->stride + x] * 65536;
                 int32_t cb_val = Cb->data[y*Cb->stride + x] - 128;
                 int32_t cr_val = Cr->data[y*Cr->stride + x] - 128;
@@ -769,8 +769,8 @@ image_u8x3_t *pjpeg_to_u8x3_baseline(pjpeg_t *pj)
             }
         }
     } else if (Cb_factor_y == Cr_factor_y && Cb_factor_x == Cr_factor_x) {
-        for (int by = 0; by < pj->height / Cb_factor_y; by++) {
-            for (int bx = 0; bx < pj->width / Cb_factor_x; bx++) {
+        for (uint32_t by = 0; by < pj->height / Cb_factor_y; by++) {
+            for (uint32_t bx = 0; bx < pj->width / Cb_factor_x; bx++) {
 
                 int32_t cb_val = Cb->data[by*Cb->stride + bx] - 128;
                 int32_t cr_val = Cr->data[by*Cr->stride + bx] - 128;
@@ -800,8 +800,8 @@ image_u8x3_t *pjpeg_to_u8x3_baseline(pjpeg_t *pj)
         }
     } else {
 
-        for (int y = 0; y < pj->height; y++) {
-            for (int x = 0; x < pj->width; x++) {
+        for (uint32_t y = 0; y < pj->height; y++) {
+            for (uint32_t x = 0; x < pj->width; x++) {
                 int32_t y_val  = Y->data[y*Y->stride + x];
                 int32_t cb_val = Cb->data[(y / Cb_factor_y)*Cb->stride + (x / Cb_factor_x)] - 128;
                 int32_t cr_val = Cr->data[(y / Cr_factor_y)*Cr->stride + (x / Cr_factor_x)] - 128;

--- a/common/string_util.c
+++ b/common/string_util.c
@@ -38,7 +38,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 struct string_buffer
 {
     char *s;
-    int alloc;
+    size_t alloc;
     size_t size; // as if strlen() was called; not counting terminating \0
 };
 
@@ -130,7 +130,7 @@ int str_diff_idx(const char * a, const char * b)
     assert(a != NULL);
     assert(b != NULL);
 
-    int i = 0;
+    size_t i = 0;
 
     size_t lena = strlen(a);
     size_t lenb = strlen(b);
@@ -293,7 +293,7 @@ char *str_tolowercase(char *s)
 	assert(s != NULL);
 
     size_t slen = strlen(s);
-    for (int i = 0; i < slen; i++) {
+    for (size_t i = 0; i < slen; i++) {
         if (s[i] >= 'A' && s[i] <= 'Z')
             s[i] = s[i] + 'a' - 'A';
     }
@@ -306,7 +306,7 @@ char *str_touppercase(char *s)
     assert(s != NULL);
 
     size_t slen = strlen(s);
-    for (int i = 0; i < slen; i++) {
+    for (size_t i = 0; i < slen; i++) {
         if (s[i] >= 'a' && s[i] <= 'z')
             s[i] = s[i] - ('a' - 'A');
     }
@@ -499,14 +499,13 @@ char string_feeder_next(string_feeder_t *sf)
 char *string_feeder_next_length(string_feeder_t *sf, size_t length)
 {
     assert(sf != NULL);
-    assert(length >= 0);
     assert(sf->pos <= sf->len);
 
     if (sf->pos + length > sf->len)
         length = sf->len - sf->pos;
 
     char *substr = calloc(length+1, sizeof(char));
-    for (int i = 0 ; i < length ; i++)
+    for (size_t i = 0 ; i < length ; i++)
         substr[i] = string_feeder_next(sf);
     return substr;
 }
@@ -522,7 +521,6 @@ char string_feeder_peek(string_feeder_t *sf)
 char *string_feeder_peek_length(string_feeder_t *sf, size_t length)
 {
     assert(sf != NULL);
-    assert(length >= 0);
     assert(sf->pos <= sf->len);
 
     if (sf->pos + length > sf->len)
@@ -550,7 +548,7 @@ void string_feeder_require(string_feeder_t *sf, const char *str)
 
     size_t len = strlen(str);
 
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         char c = string_feeder_next(sf);
         assert(c == str[i]);
     }
@@ -620,15 +618,12 @@ bool str_matches_any(const char *haystack, const char **needles, int num_needles
     return false;
 }
 
-char *str_substring(const char *str, size_t startidx, long endidx)
+char *str_substring(const char *str, size_t startidx, size_t endidx)
 {
     assert(str != NULL);
-    assert(startidx >= 0 && startidx <= strlen(str)+1);
-    assert(endidx < 0 || endidx >= startidx);
-    assert(endidx < 0 || endidx <= strlen(str)+1);
-
-    if (endidx < 0)
-        endidx = (long) strlen(str);
+    assert(startidx <= strlen(str)+1);
+    assert(endidx >= startidx);
+    assert(endidx <= strlen(str)+1);
 
     size_t blen = endidx - startidx; // not counting \0
     char *b = malloc(blen + 1);

--- a/common/string_util.c
+++ b/common/string_util.c
@@ -551,6 +551,7 @@ void string_feeder_require(string_feeder_t *sf, const char *str)
     for (size_t i = 0; i < len; i++) {
         char c = string_feeder_next(sf);
         assert(c == str[i]);
+        (void)c;
     }
 }
 

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -202,7 +202,7 @@ bool str_matches_any(const char *haystack, const char **needles, int num_needles
  *
  * Note: startidx must be >= endidx
  */
-char *str_substring(const char *str, size_t startidx, long endidx);
+char *str_substring(const char *str, size_t startidx, size_t endidx);
 
 /**
  * Retrieves the zero-based index of the beginning of the supplied substring

--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -320,7 +320,7 @@ static void maxheapify(zmaxheap_t *heap, int parent)
 
     if (betterchild != parent) {
         heap->swap(heap, parent, betterchild);
-        return maxheapify(heap, betterchild);
+        maxheapify(heap, betterchild);
     }
 }
 

--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -393,8 +393,8 @@ void zmaxheap_test()
             }
 
 
-            int32_t outv;
-            float outfv;
+            int32_t outv = 0;
+            float outfv = 0;
             int res = zmaxheap_remove_max(heap, &outv, &outfv);
             if (sz == 0) {
                 assert(res == 0);

--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -375,7 +375,6 @@ void zmaxheap_test()
             // add a value
             int32_t v = (int32_t) (random() / 1000);
             float fv = v;
-            assert(v == fv);
 
             vals[sz] = v;
             zmaxheap_add(heap, &v, fv);

--- a/common/zmaxheap.c
+++ b/common/zmaxheap.c
@@ -398,6 +398,7 @@ void zmaxheap_test()
             int res = zmaxheap_remove_max(heap, &outv, &outfv);
             if (sz == 0) {
                 assert(res == 0);
+                (void)res;
             } else {
 //                printf("%d %d %d %f\n", sz, maxv, outv, outfv);
                 assert(outv == outfv);

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -140,11 +140,7 @@ int main(int argc, char *argv[])
         cvtColor(frame, gray, COLOR_BGR2GRAY);
 
         // Make an image_u8_t header for the Mat data
-        image_u8_t im = { .width = gray.cols,
-            .height = gray.rows,
-            .stride = gray.cols,
-            .buf = gray.data
-        };
+        image_u8_t im = {gray.cols, gray.rows, gray.cols, gray.data};
 
         zarray_t *detections = apriltag_detector_detect(td, &im);
 

--- a/example/opencv_demo.cc
+++ b/example/opencv_demo.cc
@@ -119,7 +119,6 @@ int main(int argc, char *argv[])
     td->debug = getopt_get_bool(getopt, "debug");
     td->refine_edges = getopt_get_bool(getopt, "refine-edges");
 
-    float frame_counter = 0.0f;
     meter.stop();
     cout << "Detector " << famname << " initialized in "
         << std::fixed << std::setprecision(3) << meter.getTimeSec() << " seconds" << endl;

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
   <version>3.3.0</version>
@@ -7,12 +7,13 @@
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>
   <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
-
-  <author email="ebolson@umich.edu">Edwin Olson</author>
-  <author email="mkrogius@umich.edu">Max Krogius</author>
+  <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
 
   <license>BSD</license>
   <url>https://april.eecs.umich.edu/software/apriltag.html</url>
+
+  <author email="ebolson@umich.edu">Edwin Olson</author>
+  <author email="mkrogius@umich.edu">Max Krogius</author>
 
   <buildtool_depend>cmake</buildtool_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</build_depend>


### PR DESCRIPTION
This PR enables and fixes a couple of warnings throughout the code base. All warnings are reported as errors to make sure that those are not introduced again.

Note: This PR removes unused parameters from function declarations and therefore breaks API with the previous version (3.3). Therefore, the next release has to bump the minor version.