### PR TITLE
bump minor version to prepare release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(apriltag VERSION 3.3.0 LANGUAGES C)
+project(apriltag VERSION 3.4.0 LANGUAGES C)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>


### PR DESCRIPTION
The last release was more than 1 year ago and many performance and compilation improvements have been committed since then. Let's create a new release for this.

The most notable breaking changes are the removal of the Makefile, some changes in the Python bindings installation path and the removal of unused parameters in some public functions which will break API if they are used directly.

I intend to use this release to create new binary package releases for the ROS repo and conda-forge.