### PR TITLE
fix 0 length and determinant

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -445,6 +445,8 @@ static matd_t* homography_compute2(double c[4][4]) {
             }
         }
 
+        assert(max_val_idx >= 0);
+
         if (max_val < epsilon) {
             debug_print("WRN: Matrix is singular.\n");
             return NULL;

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -266,8 +266,13 @@ void fit_line(struct line_fit_pt *lfps, int sz, int i0, int i1, double *lineparm
         }
 
         double length = sqrtf(M);
-        lineparm[2] = nx/length;
-        lineparm[3] = ny/length;
+        if (fabs(length) < 1e-12) {
+            lineparm[2] = lineparm[3] = 0;
+        }
+        else {
+            lineparm[2] = nx/length;
+            lineparm[3] = ny/length;
+        }
     }
 
     // sum of squared errors =

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -899,11 +899,11 @@ int fit_quad(
         double det = A00 * A11 - A10 * A01;
 
         // inverse.
-        double W00 = A11 / det, W01 = -A01 / det;
         if (fabs(det) < 0.001) {
             res = 0;
             goto finish;
         }
+        double W00 = A11 / det, W01 = -A01 / det;
 
         // solve
         double L0 = W00*B0 + W01*B1;


### PR DESCRIPTION
This correctly checks for 0 length and determinant and avoids division by zero issues. Supersedes https://github.com/AprilRobotics/apriltag/pull/213 (@jrepp) and fixes https://github.com/AprilRobotics/apriltag/issues/72.