### PR TITLE
Improve CMakeLists config path by using CMAKE_CURRENT_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ export(TARGETS apriltag
 
 # install pkgconfig file
 configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
-install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 


### PR DESCRIPTION
Change CMAKE_BINARY_DIR to CMAKE_CURRENT_BINARY_DIR during configuration. This is useful when the project is a subdirectory/ submodule another project (e.g. [apriltags_ros](https://github.com/berndpfrommer/apriltag/tree/ros2)).