### PR TITLE
prepare for ROS "Jazzy"

### DIFF
--- a/.github/workflows/colcon-workspace.yml
+++ b/.github/workflows/colcon-workspace.yml
@@ -11,7 +11,6 @@ jobs:
 
     strategy:
       matrix:
-        ros_distribution: [noetic, humble]
         include:
           - docker_image: ubuntu:20.04
             ros_distribution: noetic
@@ -19,6 +18,10 @@ jobs:
 
           - docker_image: ubuntu:22.04
             ros_distribution: humble
+            ros_version: 2
+
+          - docker_image: ubuntu:24.04
+            ros_distribution: jazzy
             ros_version: 2
 
     container:
@@ -58,12 +61,14 @@ jobs:
 
     strategy:
       matrix:
-        ros_distribution: [noetic, humble]
         include:
           - ros_distribution: noetic
             ros_version: 1
 
           - ros_distribution: humble
+            ros_version: 2
+
+          - ros_distribution: jazzy
             ros_version: 2
 
     steps:
@@ -96,7 +101,7 @@ jobs:
 
     strategy:
       matrix:
-        ros_distribution: [humble]
+        ros_distribution: [humble, jazzy]
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(apriltag VERSION 3.4.0 LANGUAGES C)
+project(apriltag VERSION 3.4.1 LANGUAGES C)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
-  <version>3.4.0</version>
+  <version>3.4.1</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>


### PR DESCRIPTION
This sets up the CI and fixes some errors and warnings for the upcoming ROS release "jazzy" on Ubuntu 24.04. I am incrementing the patch version for a new bloom release to "rolling".