### PR TITLE
fix homography assert

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -445,7 +445,9 @@ static matd_t* homography_compute2(double c[4][4]) {
             }
         }
 
-        assert(max_val_idx >= 0);
+        if (max_val_idx < 0) {
+            return NULL;
+        }
 
         if (max_val < epsilon) {
             debug_print("WRN: Matrix is singular.\n");

--- a/common/image_u8.c
+++ b/common/image_u8.c
@@ -265,6 +265,9 @@ void image_u8_draw_annulus(image_u8_t *im, float x0, float y0, float r0, float r
 void image_u8_draw_line(image_u8_t *im, float x0, float y0, float x1, float y1, int v, int width)
 {
     double dist = sqrtf((y1-y0)*(y1-y0) + (x1-x0)*(x1-x0));
+    if (dist == 0) {
+        return;
+    }
     double delta = 0.5 / dist;
 
     // terrible line drawing code


### PR DESCRIPTION
When the "Find best row to swap with." section in `homography_compute2` would not find a value greater than 0 in a row, `max_val_idx` would stay `-1` and maybe be used later to index a matrix. We protected against the negative indexing (in debug mode) by checking for a positive index in 3a0a155d5bc3bdcef34275f7c51f56e9cfd34e13.

But this causes issues for false-positive quad detections (#321). In this particular case, ignoreing the negative index would lead to `return NULL;` via `max_val < epsilon`, so we can also just `return NULL;` here and ignore that quad instead of stopping the process.

Fixes #321 .

@mkrogius As far as I understand `c[4][4]` contains the 4 correspondences from the 2D pixel coordinates in the image to the 2D coordinates of the unit square with +/-1 edge coordinates. But I don't fully understand why `homography_compute2` does not deal with this special case of axis-aligned quads. Do you see a better way to handle this case?