### PR TITLE
test blooming on the CI

### DIFF
--- a/.github/workflows/bloom.yml
+++ b/.github/workflows/bloom.yml
@@ -1,0 +1,53 @@
+name: bloom
+
+on: [push, pull_request]
+
+jobs:
+  build_linux:
+    name: "Ubuntu (${{ matrix.ros_distribution }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - docker_image: ubuntu:20.04
+            ros_distribution: noetic
+
+          - docker_image: ubuntu:22.04
+            ros_distribution: humble
+
+          - docker_image: ubuntu:24.04
+            ros_distribution: jazzy
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+      - name: install core dependencies
+        run: |
+          apt update
+          apt install -y --no-install-recommends git ca-certificates
+
+      - uses: actions/checkout@v4
+
+      - uses: ros-tooling/setup-ros@v0.7
+
+      - name: install build tool dependencies
+        run: |
+          apt install -y --no-install-recommends devscripts equivs python3-bloom
+
+      - name: bloom
+        run: |
+          rosdep update
+          bloom-generate rosdebian --ros-distro ${{ matrix.ros_distribution }}
+          mk-build-deps
+          apt install -y --no-install-recommends ./ros-${{ matrix.ros_distribution }}-apriltag-build-deps_*_all.deb
+          dpkg-buildpackage -b
+
+      - name: install bloomed packages
+        run: |
+          apt install -y --no-install-recommends ../ros-${{ matrix.ros_distribution }}-apriltag_*.deb ../ros-${{ matrix.ros_distribution }}-apriltag-dbgsym_*.ddeb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(apriltag VERSION 3.4.1 LANGUAGES C)
+project(apriltag VERSION 3.4.2 LANGUAGES C)
 
 if(POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/common/matd.c
+++ b/common/matd.c
@@ -1148,7 +1148,7 @@ static matd_svd_t matd_svd_tall(matd_t *A, int flags)
     assert(maxiters > 0); // reassure clang
     int iter;
 
-    double maxv; // maximum non-zero value being reduced this iteration
+    double maxv = 0; // maximum non-zero value being reduced this iteration
 
     double tol = 1E-10;
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>apriltag</name>
-  <version>3.4.1</version>
+  <version>3.4.2</version>
   <description>AprilTag detector library</description>
 
   <maintainer email="mkrogius@umich.edu">Max Krogius</maintainer>


### PR DESCRIPTION
Even the Ubuntu 24.04 CI https://github.com/AprilRobotics/apriltag/pull/327 could not reproduce some of the "may be used uninitialized" errors that caused blooming failures on the ROS build farm. This PR now directly adds blooming tests to the CI so we can catch these kinds of build issues before releasing a package via bloom.