### PR TITLE
Changed Nthreads to threads in apriltag_py_type.docstring

### DIFF
--- a/apriltag_py_type.docstring
+++ b/apriltag_py_type.docstring
@@ -54,7 +54,7 @@ The constructor takes a number of arguments:
 
 All the other arguments are optional:
 
-- Nthreads: how many threads the detector should use. Default is 1
+- threads: how many threads the detector should use. Default is 1
 
 - maxhamming: max number of corrected bits. Larger values guzzle RAM. Default is
   1


### PR DESCRIPTION
This prevents confusion since `Nthreads` is an invalid keyword 
The actual keyword for "Nthreads" is threads