### PR TITLE
apriltag_quad_thresh: Prevent conversion from NaN to int

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -1810,7 +1810,8 @@ zarray_t* fit_quads(apriltag_detector_t *td, int w, int h, zarray_t* clusters, i
         normal_border |= !family->reversed_border;
         reversed_border |= family->reversed_border;
     }
-    min_tag_width /= td->quad_decimate;
+    if (td->quad_decimate > 1)
+        min_tag_width /= td->quad_decimate;
     if (min_tag_width < 3) {
         min_tag_width = 3;
     }


### PR DESCRIPTION
If the user supplied quad_decimate value of 0.0, it works in most places, but in apriltag_quad_thresh, it led to undefined behavior after dividing by this value.

The symptoms are the triciker that on x86/GCC, the undefined behavior leads to -INT_MAX, which gets corrected to 3 pixels by the following lines of code. However, on arm64/GCC, it results in +INT_MAX, which does not get corrected and leads to a running detector which will never detect anything.