### PR TITLE
Use _WIN32 macro everywhere

### DIFF
--- a/common/workerpool.c
+++ b/common/workerpool.c
@@ -198,7 +198,7 @@ void workerpool_run(workerpool_t *wp)
 
 int workerpool_get_nprocs()
 {
-#ifdef WIN32
+#ifdef _WIN32
     SYSTEM_INFO sysinfo;
     GetSystemInfo(&sysinfo);
     return sysinfo.dwNumberOfProcessors;


### PR DESCRIPTION
Looks like a typo to me.

---

There is no `WIN32` macros (at least with usual compilers):
- http://jdebp.info/FGA/predefined-macros-platform.html
- https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
- https://sourceforge.net/p/predef/wiki/OperatingSystems/
- http://docwiki.embarcadero.com/RADStudio/Athens/en/Predefined_Macros