### PR TITLE
fix refine_edges() and the coordinates recovery when quad_decimate > …

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -797,6 +797,7 @@ static void refine_edges(apriltag_detector_t *td, image_u8_t *im_orig, struct qu
             int steps_per_unit = 4;
             double step_length = 1.0 / steps_per_unit;
             int max_steps = 2 * steps_per_unit * range + 1;
+            double delta = 0.5;
 
             // XXX tunable step size.
             for (int step = 0; step < max_steps; ++step) {
@@ -811,8 +812,8 @@ static void refine_edges(apriltag_detector_t *td, image_u8_t *im_orig, struct qu
                 // noise.
                 double grange = 1;
 
-                double x1 = x0 + (n + grange)*nx;
-                double y1 = y0 + (n + grange)*ny;
+                double x1 = x0 + (n + grange)*nx - delta;
+                double y1 = y0 + (n + grange)*ny - delta;
                 double x1i_d, y1i_d, a1, b1;
                 a1 = modf(x1, &x1i_d);
                 b1 = modf(y1, &y1i_d);
@@ -821,8 +822,8 @@ static void refine_edges(apriltag_detector_t *td, image_u8_t *im_orig, struct qu
                 if (x1i < 0 || x1i + 1 >= im_orig->width || y1i < 0 || y1i + 1 >= im_orig->height)
                     continue;
 
-                double x2 = x0 + (n - grange)*nx;
-                double y2 = y0 + (n - grange)*ny;
+                double x2 = x0 + (n - grange)*nx - delta;
+                double y2 = y0 + (n - grange)*ny - delta;
                 double x2i_d, y2i_d, a2, b2;
                 a2 = modf(x2, &x2i_d);
                 b2 = modf(y2, &y2i_d);
@@ -1115,13 +1116,8 @@ zarray_t *apriltag_detector_detect(apriltag_detector_t *td, image_u8_t *im_orig)
             zarray_get_volatile(quads, i, &q);
 
             for (int j = 0; j < 4; j++) {
-                if (td->quad_decimate == 1.5) {
-                    q->p[j][0] *= td->quad_decimate;
-                    q->p[j][1] *= td->quad_decimate;
-                } else {
-                    q->p[j][0] = (q->p[j][0] - 0.5)*td->quad_decimate + 0.5;
-                    q->p[j][1] = (q->p[j][1] - 0.5)*td->quad_decimate + 0.5;
-                }
+                q->p[j][0] *= td->quad_decimate;
+                q->p[j][1] *= td->quad_decimate;
             }
         }
     }

--- a/apriltag_detect.docstring
+++ b/apriltag_detect.docstring
@@ -42,7 +42,9 @@ a tuple containing the detections. Each detection is a dict with keys:
 
 - id: integer identifying each detected tag
 
-- center: pixel coordinates of the center of each detection
+- center: pixel coordinates of the center of each detection.  NOTE: Please be
+  cautious regarding the image coordinate convention. Here, we define (0,0) as
+  the left-top corner (not the center point) of the left-top-most pixel.
 
 - lb-rb-rt-lt: pixel coordinates of the 4 corners of each detection. The order
   is left-bottom, right-bottom, right-top, left-top


### PR DESCRIPTION
fix refine_edges() and the coordinates recovery when quad_decimate > 1 (fixes #334, fixes #345)

1. Fix the inconsistent image coordinate conventions used in the code: the convention that (0,0) be the left top corner of the first pixel is adopted by this PR.
2. Fix refine_edges(): Use continuous coordinates and bilinear interpolation (instead of discrete coordinates) when retrieving grayscale values from the input image. Using discrete coordinates might incur extra errors thus unstable.