### PR TITLE
Dissable threads at compile time with NOTHREADS option

### DIFF
--- a/common/pthreads_cross.c
+++ b/common/pthreads_cross.c
@@ -246,9 +246,8 @@ unsigned int pcthread_get_num_procs()
     return sysinfo.dwNumberOfProcessors;
 }
 
-#else
+#elif !defined(_POSIX_THREADS) /* Not _WIN32. */
 
-#ifdef NOTHREADS
 int pthread_create(pthread_t *thread, pthread_attr_t *attr, void *(*start_routine)(void *), void *arg) { return 0; }
 int pthread_join(pthread_t thread, void **value_ptr) { return 0; }
 int pthread_detach(pthread_t thread) { return 0; }
@@ -267,12 +266,13 @@ int pthread_cond_broadcast(pthread_cond_t *cond) { return 0; }
 
 int sched_yield(void) { return 0; }
 unsigned int pcthread_get_num_procs() { return 1; }
-#else
+
+#else /* Not _WIN32 and _POSIX_THREADS is defined. */
+
 #include <unistd.h>
 unsigned int pcthread_get_num_procs()
 {
     return (unsigned int)sysconf(_SC_NPROCESSORS_ONLN);
 }
-#endif
 
 #endif

--- a/common/pthreads_cross.c
+++ b/common/pthreads_cross.c
@@ -248,9 +248,31 @@ unsigned int pcthread_get_num_procs()
 
 #else
 
+#ifdef NOTHREADS
+int pthread_create(pthread_t *thread, pthread_attr_t *attr, void *(*start_routine)(void *), void *arg) { return 0; }
+int pthread_join(pthread_t thread, void **value_ptr) { return 0; }
+int pthread_detach(pthread_t thread) { return 0; }
+
+int pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *attr) { return 0; }
+int pthread_mutex_destroy(pthread_mutex_t *mutex) { return 0; }
+int pthread_mutex_lock(pthread_mutex_t *mutex) { return 0; }
+int pthread_mutex_unlock(pthread_mutex_t *mutex) { return 0; }
+
+int pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *attr) { return 0; }
+int pthread_cond_destroy(pthread_cond_t *cond) { return 0; }
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) { return 0; }
+int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime) { return 0; }
+int pthread_cond_signal(pthread_cond_t *cond) { return 0; }
+int pthread_cond_broadcast(pthread_cond_t *cond) { return 0; }
+
+int sched_yield(void) { return 0; }
+unsigned int pcthread_get_num_procs() { return 1; }
+#else
 #include <unistd.h>
 unsigned int pcthread_get_num_procs()
 {
     return (unsigned int)sysconf(_SC_NPROCESSORS_ONLN);
 }
+#endif
+
 #endif

--- a/common/pthreads_cross.h
+++ b/common/pthreads_cross.h
@@ -23,6 +23,7 @@ SOFTWARE.
 #ifndef __CPTHREAD_H__
 #define __CPTHREAD_H__
 
+#ifndef NOTHREADS
 #ifdef _WIN32
 #include <stdbool.h>
 #include <windows.h>
@@ -30,6 +31,8 @@ SOFTWARE.
 #include <pthread.h>
 #include <sched.h>
 #endif
+#endif
+
 #include <time.h>
 
 #ifdef _WIN32
@@ -67,6 +70,25 @@ int sched_yield(void);
 #endif
 #endif
 
+#ifdef NOTHREADS
+int pthread_create(pthread_t *thread, pthread_attr_t *attr, void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **value_ptr);
+int pthread_detach(pthread_t thread);
+
+int pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *attr);
+int pthread_mutex_destroy(pthread_mutex_t *mutex);
+int pthread_mutex_lock(pthread_mutex_t *mutex);
+int pthread_mutex_unlock(pthread_mutex_t *mutex);
+
+int pthread_cond_init(pthread_cond_t *cond, pthread_condattr_t *attr);
+int pthread_cond_destroy(pthread_cond_t *cond);
+int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+int pthread_cond_signal(pthread_cond_t *cond);
+int pthread_cond_broadcast(pthread_cond_t *cond);
+
+int sched_yield(void);
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/common/workerpool.c
+++ b/common/workerpool.c
@@ -96,6 +96,9 @@ void *worker_thread(void *p)
 workerpool_t *workerpool_create(int nthreads)
 {
     assert(nthreads > 0);
+#ifdef NOTHREADS
+    nthreads = 1;
+#endif
 
     workerpool_t *wp = calloc(1, sizeof(workerpool_t));
     wp->nthreads = nthreads;


### PR DESCRIPTION
Pull request for #355.
My initial idea was to define empty `pthread_*` functions in `pthreads_cross.{c,h}` so that when other code uses them the symbols would get resolved. Then I would enforce `worker_pool->nthreads==1` so that these vacuous `pthread_*` functions didnt get used.
Problem is that these functions need pthread types in their signatures and we cant just typedef our own because its hard to predict if the standard libs will already define them. For example, I'm trying to cross compile to an embedded arm device for which `#import <time.h>` imports `sys/types.h` which imports `sys/pthread_types.h` which defines pthread types even though `pthread.h` does not declare `pthread_*` functions!

So the way it works now is if the user defines `NOTHREADS` then all `#include <pthread.h>` and all uses of `pthread` types or functions are dissabled using `#ifdef`s. Then in `workerpool.c` we just ignore the `nthreads` argument to `workerpool_create`.

Also `workerpool.c:workerpool_get_nprocs` and `common/pthreads_cross.c:pcthread_get_num_procs` were re-implementing the same function. So I made `workerpool_get_nprocs` just call `pcthread_get_num_procs`. If `NOTHREADS` is defined then `pcthread_get_num_procs` returns `1`.

I've tested this quickly by running the following code with and without NOTHREADS.
```
#include <stdio.h>
#include "apriltag.h"
#include "tag25h9.h"
int main(int argc, char *argv[])
{
    image_u8_t* im = image_u8_create_from_pnm("noexist.pnm");
    apriltag_detector_t *td = apriltag_detector_create();
    td->nthreads = 5;
    apriltag_family_t *tf = tag25h9_create();
    apriltag_detector_add_family(td, tf);
    zarray_t *detections = apriltag_detector_detect(td, im);
    for (int i = 0; i < zarray_size(detections); i++) {
        apriltag_detection_t *det;
        zarray_get(detections, i, &det);
        printf("%f %f\n", det->c[0], det->c[1]);
    }
    apriltag_detections_destroy(detections);
    tag25h9_destroy(tf);
    apriltag_detector_destroy(td);
}

```

Note that these changes have been made on top of my Remove CRLF line ends commit. So diffing the branch makes it look like all the lines in `pthreads_cross.{c,h}` have changed even though only some have.