### PR TITLE
Call enable_testing() in top-level project

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Test
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       run: |
-        ctest --build-config ${{ matrix.build_type }} --no-tests=error --output-on-failure --verbose --test-dir test/
+        ctest --build-config ${{ matrix.build_type }} --no-tests=error --output-on-failure --verbose
 
     - name: Test Python Module Import
       working-directory: ${{ steps.strings.outputs.build-output-dir }}

--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -57,6 +57,6 @@ jobs:
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --target install
 
     - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}/test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
       run: |
         ctest --no-tests=error --output-on-failure --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,5 +215,6 @@ if (BUILD_EXAMPLES)
 endif()
 
 if(BUILD_TESTING)
+    enable_testing()
     add_subdirectory(test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 add_library(getline OBJECT getline.c)
 
 add_executable(test_detection test_detection.c)


### PR DESCRIPTION
Per CMake documentation, this should be called in the top-level CMakeLists.txt so that testing is enabled for the _project_, and not a subdirectory thereof. This will allow tools like colcon to discover the tests.