### PR TITLE
Modify the memory allocation method of `matd_t` to comply with ISO standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,14 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Werror)
-    # add_compile_options(-Wpedantic)
+    add_compile_options(-Wpedantic)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+        add_compile_options(
+            -Wno-gnu-zero-variadic-macro-arguments
+            -Wno-strict-prototypes
+            -Wno-static-in-inline
+        )
+    endif()
     add_compile_options(-Wno-shift-negative-value)
 endif()
 

--- a/common/matd.c
+++ b/common/matd.c
@@ -51,18 +51,20 @@ matd_t *matd_create(int rows, int cols)
     if (rows == 0 || cols == 0)
         return matd_create_scalar(0);
 
-    matd_t *m = calloc(1, sizeof(matd_t) + (rows*cols*sizeof(double)));
+    matd_t *m = calloc(1, sizeof(matd_t));
     m->nrows = rows;
     m->ncols = cols;
+    m->data = calloc(rows * cols, sizeof(double));
 
     return m;
 }
 
 matd_t *matd_create_scalar(TYPE v)
 {
-    matd_t *m = calloc(1, sizeof(matd_t) + sizeof(double));
+    matd_t *m = calloc(1, sizeof(matd_t));
     m->nrows = 0;
     m->ncols = 0;
+    m->data = calloc(1, sizeof(double));
     m->data[0] = v;
 
     return m;
@@ -220,7 +222,8 @@ void matd_destroy(matd_t *m)
     if (!m)
         return;
 
-    assert(m != NULL);
+    assert(m->data != NULL);
+    free(m->data);
     free(m);
 }
 

--- a/common/matd.h
+++ b/common/matd.h
@@ -45,8 +45,7 @@ extern "C" {
 typedef struct
 {
     unsigned int nrows, ncols;
-    double data[];
-//    double *data;
+    double *data;
 } matd_t;
 
 #define MATD_ALLOC(name, nrows, ncols) double name ## _storage [nrows*ncols]; matd_t name = { .nrows = nrows, .ncols = ncols, .data = &name ## _storage };


### PR DESCRIPTION
The original way of writing `matd_t` was

```c
typedef struct
{
    unsigned int nrows, ncols;
    double data[];
//    double *data;
} matd_t;
```

which does not conform to the ISO standard. For example, it will generate a warning in C++ compilers such as g++, with the following message:

```
/path/to/apriltag/common/matd.h:48:12: warning: ISO C++ forbids flexible array member ‘data’ [-Wpedantic]
   48 |     double data[];
      |            ^~~~
```

Therefore, it was changed to use `double *`, and separate memory was allocated for `m` and `m->data`. Additionally, resource release for `m->data` was added in the `matd_destroy` function.