### PR TITLE
Install CMake config to architecture-specific location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
-set(config_install_dir "share/${PROJECT_NAME}/cmake")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake")
 
 # Include module with fuction 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
As an architecture-specific CMake project, the CMake config files should be installed to an architecture-specific location.

This issue was identified during the process of packaging `apriltag` for inclusion in Fedora Linux and EPEL[1]. You can see a similar patch was added to the debian build process for Ubuntu[2].

Related docs: https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2173758#c17
[2] https://salsa.debian.org/science-team/apriltag/-/blob/master/debian/patches/cmake-into-arch-specific-path.patch