### PR TITLE
Add insertion sort to ptsort

### DIFF
--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -713,6 +713,19 @@ static inline void ptsort(struct pt *pts, int sz)
 
 #undef MAYBE_SWAP
 
+    if (sz <= 32) {
+        for (int i = 0; i < sz; i++) {
+            struct pt key = pts[i];
+            int j = i - 1;
+            while (j >= 0 && pt_compare_angle(&pts[j], &key) > 0) {
+                pts[j + 1] = pts[j];
+                j--;
+            }
+            pts[j + 1] = key;
+        }
+        return;
+    }
+
     // a merge sort with temp storage.
 
     struct pt *tmp = malloc(sizeof(struct pt) * sz);


### PR DESCRIPTION
Provides a nice little speed boost. I'm sure there's a more optimal sorting method that could improve this even more.

## Before

```
build/apriltag_demo -t 1 -i 4 -x 1.0 -f tagStandard52h13 vide2.jpg
...
iter 4 / 4
loading vide2.jpg
image: vide2.jpg 3088x2064
 0                             init        0.000000 ms        0.000000 ms
 1                       blur/sharp        0.000000 ms        0.000000 ms
 2                        threshold        5.802000 ms        5.802000 ms
 3                        unionfind       22.402000 ms       28.204000 ms
 4                    make clusters       42.181000 ms       70.385000 ms
 5            fit quads to clusters       67.911000 ms      138.296000 ms
 6                            quads        1.687000 ms      139.983000 ms
 7                decode+refinement        8.909000 ms      148.892000 ms
 8                        reconcile        0.001000 ms      148.893000 ms
 9                     debug output        0.000000 ms      148.893000 ms
10                          cleanup        0.031000 ms      148.924000 ms
hamm     0     0     0     0     0     0     0     0     0     0      148.924   845
Summary
hamm     0     0     0     0     0     0     0     0     0     0      148.924   845
```

## After

```
build/apriltag_demo -t 1 -i 4 -x 1.0 -f tagStandard52h13 vide2.jpg
...
iter 4 / 4
loading vide2.jpg
image: vide2.jpg 3088x2064
 0                             init        0.000000 ms        0.000000 ms
 1                       blur/sharp        0.000000 ms        0.000000 ms
 2                        threshold        5.639000 ms        5.639000 ms
 3                        unionfind       22.484000 ms       28.123000 ms
 4                    make clusters       42.236000 ms       70.359000 ms
 5            fit quads to clusters       58.481000 ms      128.840000 ms
 6                            quads        1.848000 ms      130.688000 ms
 7                decode+refinement        8.769000 ms      139.457000 ms
 8                        reconcile        0.000000 ms      139.457000 ms
 9                     debug output        0.000000 ms      139.457000 ms
10                          cleanup        0.030000 ms      139.487000 ms
hamm     0     0     0     0     0     0     0     0     0     0      139.487   836
Summary
hamm     0     0     0     0     0     0     0     0     0     0      139.487   836
```