### PR TITLE
Release Python Global Interpreter Lock During Detection

### DIFF
--- a/apriltag_pywrap.c
+++ b/apriltag_pywrap.c
@@ -243,7 +243,11 @@ static PyObject* apriltag_detect(apriltag_py_t* self,
                      .stride = strides[0],
                      .buf    = PyArray_DATA(image)};
 
-    zarray_t* detections = apriltag_detector_detect(self->td, &im);
+    zarray_t *detections;  // Declare detections variable outside of the GIL block
+    Py_BEGIN_ALLOW_THREADS  // Acquire the GIL before running detection
+        detections = apriltag_detector_detect(self->td, &im);
+    Py_END_ALLOW_THREADS  // Release the GIL after detection completes
+
     int N = zarray_size(detections);
 
     if (N == 0 && errno == EAGAIN){


### PR DESCRIPTION
**Summary:**
This PR releases Python’s Global Interpreter Lock (GIL) during the CPU-intensive detection stage. This allows other threads in the Python process to run concurrently.

**Details:**
- The GIL prevents multiple Python threads from executing in parallel. If the GIL is not released, detection blocks the entire Python process, starving other threads of CPU.
- On low-resolution images or with high decimate values, detection is fast (milliseconds), so blocking is minimal. With high-res images or low decimate values, detection can take up to a second, making GIL release critical for multi-threaded applications.
- Manual GIL release can be unsafe if C code interacts with Python objects or is not thread-safe. Here, this is not an issue because `apriltag_detector_detect()` is implemented purely in C and does not interact with Python objects.

**References:**
[Python docs: Releasing the GIL from extension code](https://docs.python.org/3/c-api/init.html#releasing-the-gil-from-extension-code)

**Testing:**
Changes are tested and work as intended.