### PR TITLE
add MXE cross-compilation support with pthread and gettimeofda…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,24 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_EXAMPLES "Build example executables" ON)
 option(ASAN "Use AddressSanitizer for debug builds to detect memory issues" OFF)
 
+
+include(CheckIncludeFile)
+check_include_file(pthread.h HAVE_PTHREAD)
+if(HAVE_PTHREAD)
+    add_definitions(-DHAVE_PTHREAD)
+    message(STATUS "pthread.h found, using POSIX thread support")
+endif()
+# gettimeofday
+check_include_file(sys/time.h HAVE_SYS_TIME_H)
+if(HAVE_SYS_TIME_H)
+    add_definitions(-DHAVE_SYS_TIME_H)
+    message(STATUS "sys/time.h found, using gettimeofday()")
+else()
+    message(WARNING "sys/time.h not found, gettimeofday() will not be available")
+endif()
+
+
+
 if (ASAN)
     set(ASAN_FLAGS "\
         -fsanitize=address \

--- a/common/pthreads_cross.c
+++ b/common/pthreads_cross.c
@@ -22,7 +22,9 @@ SOFTWARE.
 
 #include "common/pthreads_cross.h"
 
-#ifdef _WIN32
+
+
+#if defined(_WIN32) && !defined(HAVE_PTHREAD)
 
 typedef struct {
     SRWLOCK lock;
@@ -238,6 +240,12 @@ unsigned int timespec_to_ms(const struct timespec *abstime)
     return ((abstime->tv_sec - time(NULL)) * 1000) + (abstime->tv_nsec / 1000000);
 }
 
+#endif
+
+
+#if defined(_WIN32)
+#include <windows.h>
+
 unsigned int pcthread_get_num_procs()
 {
     SYSTEM_INFO sysinfo;
@@ -245,7 +253,6 @@ unsigned int pcthread_get_num_procs()
     GetSystemInfo(&sysinfo);
     return sysinfo.dwNumberOfProcessors;
 }
-
 #else
 
 #include <unistd.h>

--- a/common/pthreads_cross.h
+++ b/common/pthreads_cross.h
@@ -23,7 +23,7 @@ SOFTWARE.
 #ifndef __CPTHREAD_H__
 #define __CPTHREAD_H__
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(HAVE_PTHREAD)
 #include <stdbool.h>
 #include <windows.h>
 #else
@@ -32,7 +32,7 @@ SOFTWARE.
 #endif
 #include <time.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(HAVE_PTHREAD)
 
 typedef CRITICAL_SECTION pthread_mutex_t;
 typedef void pthread_mutexattr_t;

--- a/common/time_util.h
+++ b/common/time_util.h
@@ -31,10 +31,16 @@ either expressed or implied, of the Regents of The University of Michigan.
 #include <stdint.h>
 #include <time.h>
 
-#ifdef _WIN32
+#if defined(_WIN32)
+#if !defined(HAVE_SYS_TIME_H)
 #include <Winsock2.h>
+#endif
+
+#include <windows.h>
+#define sleep(x) Sleep((x)*1000)
 typedef long long suseconds_t;
 #endif
+
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
- Added `CheckIncludeFile` to detect presence of pthread.h and sys/time.h
- Ensures the project can be cross-compiled using MXE