### PR TITLE
replace deprecated 'windows-2019' runner with 'windows-latest'

### DIFF
--- a/.github/workflows/colcon-workspace.yml
+++ b/.github/workflows/colcon-workspace.yml
@@ -57,7 +57,7 @@ jobs:
   build_windows:
     name: "Windows (${{ matrix.ros_distribution }})"
 
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Currently, the CI fails on Windows with

> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
