### PR TITLE
Permit to specify the Python install location as CMake command line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,8 +193,10 @@ if(BUILD_PYTHON_WRAPPER AND Python3_Development_FOUND AND Python3_NumPy_FOUND)
     target_link_libraries(${apriltag_py_target} PRIVATE apriltag Python3::NumPy)
     target_include_directories(${apriltag_py_target} PRIVATE ${PROJECT_BINARY_DIR})
 
-    set(PY_DEST ${CMAKE_INSTALL_PREFIX}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/)
-    install(TARGETS ${apriltag_py_target} LIBRARY DESTINATION ${PY_DEST})
+    if(NOT DEFINED APRILTAG_PYTHON_BINDINGS_INSTALL_FOLDER)
+        set(APRILTAG_PYTHON_BINDINGS_INSTALL_FOLDER ${CMAKE_INSTALL_PREFIX}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/)
+    endif()
+    install(TARGETS ${apriltag_py_target} LIBRARY DESTINATION ${APRILTAG_PYTHON_BINDINGS_INSTALL_FOLDER})
 elseif(BUILD_PYTHON_WRAPPER)
     message(WARNING
         "Python bindings requested (BUILD_PYTHON_WRAPPER=ON) but Development and NumPy not found. "


### PR DESCRIPTION
The current build system hardcodes the Python install location in `${CMAKE_INSTALL_PREFIX}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/` . While this works fine in many context, in some cases (for example in packaging) it may be necessary to use a different value, for example:

* In conda Windows install, the `CMAKE_INSTALL_PREFIX` is set to `%CONDA_PREFIX%\Library`, while the location where Python libraries should be installed is `%CMAKE_INSTALL_PREFIX%\lib\site-packages\`
* In debian packaging, the Python libraries should be installed in `${CMAKE_INSTALL_PREFIX}/python3/dist-packages/`  (see for example this patch in the debian packaging of apriltag: https://sources.debian.org/patches/apriltag/3.4.2-1/0003-Python-library-is-installed-to-the-proper-place.patch/)

To allow this use cases without the need of patching the source code, this PR permits to override the Python install location using the `APRILTAG_PYTHON_BINDINGS_INSTALL_FOLDER` variable. If the variable is not defined, the behavior remains the existing one before this PR.