### PR TITLE
Fix opencv example readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ Note that this library has no external dependencies. Most applications
 will require, at minimum, a method for acquiring images.
 
 See example/opencv_demo.cc for an example of using AprilTag in C++ with OpenCV.
-After building the project locally (i.e. omitting `--target install` from the 
-cmake command) you can run the example application with:
+After building the repository you can run the example opencv application with:
 
     $ ./build/opencv_demo
 


### PR DESCRIPTION
The opencv example readme section directs users to run the following commands:

```
$ cd examples
$ make opencv_demo
```

The first command does not work because the folder is called "example/" not "examples/" and the second command fails with unknown include errors because there is no build configuration or file or Makefile to actually orchestrate building the opencv demo.

Given that the examples are built by default I propose that the readme is changed to simply instruct people to build and then run `./build/opencv_demo`. This works like  charm and is easy to understand. 