### PR TITLE
fix: windows crosscompiling

### DIFF
--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -1,0 +1,86 @@
+name: Cross compilation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+  env:
+    DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        shared_libs: ['ON', 'OFF']
+
+    steps:
+    - name: install dependencies
+      run: |
+        apt update
+        apt install -y --no-install-recommends cmake ninja-build gcc-mingw-w64-x86-64
+        apt install -y --no-install-recommends python3-dev python3-numpy
+
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=$GITHUB_WORKSPACE/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -G Ninja
+        -D CMAKE_SYSTEM_NAME=Windows 
+        -D CMAKE_C_COMPILER=/usr/bin/x86_64-w64-mingw32-gcc
+        -D CMAKE_BUILD_TYPE=Release
+        -D BUILD_SHARED_LIBS=${{ matrix.shared_libs }}
+        -D BUILD_TESTING=ON
+        -S $GITHUB_WORKSPACE
+
+    - name: Build & Install
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --target install
+
+    - name: add DLL to test folder
+      if: matrix.shared_libs == 'ON'
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      run: |
+        cp *apriltag.dll test/
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: cross-compilation-build-sharedlib-${{ matrix.shared_libs }}
+        path: ${{ steps.strings.outputs.build-output-dir }}
+
+  test:
+    needs: build
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        shared_libs: ['ON', 'OFF']
+    
+    steps:
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=$GITHUB_WORKSPACE/build" >> "$GITHUB_OUTPUT"
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: cross-compilation-build-sharedlib-${{ matrix.shared_libs }}
+        path: ${{ steps.strings.outputs.build-output-dir }}
+
+    - name: Test
+      working-directory: ${{ steps.strings.outputs.build-output-dir }}
+      run: |
+        ctest --no-tests=error --output-on-failure --verbose

--- a/common/time_util.h
+++ b/common/time_util.h
@@ -32,7 +32,11 @@ either expressed or implied, of the Regents of The University of Michigan.
 #include <time.h>
 
 #ifdef _WIN32
+#if defined __has_include && __has_include ("winsock2.h")
+#include <winsock2.h>
+#else
 #include <Winsock2.h>
+#endif
 typedef long long suseconds_t;
 #endif
 


### PR DESCRIPTION
Windows crosscompilation is broken again. This fixes the issue. This is due to the fact that in mingw, `Winsock2.h` is `winsock2.h`, and is case sensitive. Might be `winsock2.h` in windows too, but I don't have a computer running windows to check, sadly.