### PR TITLE
corrects capacity calculations

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -207,10 +207,10 @@ static void quick_decode_init(apriltag_family_t *family, int maxhamming)
         capacity += family->ncodes * nbits;
 
     if (maxhamming >= 2)
-        capacity += family->ncodes * nbits * (nbits-1);
+        capacity += family->ncodes * (nbits * (nbits-1)) / 2;
 
     if (maxhamming >= 3)
-        capacity += family->ncodes * nbits * (nbits-1) * (nbits-2);
+        capacity += family->ncodes * nbits * ((nbits-1) * (nbits-2)) / 6;
 
     qd->nentries = capacity * 3;
 


### PR DESCRIPTION
This fixes the error in the capacity calculation math, where more than 6 times more space was being allocated than needed, because the capacity math used permutations instead of combination