### PR TITLE
Remove redundant cluster size check

### DIFF
--- a/apriltag.c
+++ b/apriltag.c
@@ -378,7 +378,7 @@ apriltag_detector_t *apriltag_detector_create()
     td->quad_sigma = 0.0;
 
     td->qtp.max_nmaxima = 10;
-    td->qtp.min_cluster_pixels = 5;
+    td->qtp.min_cluster_pixels = 24;
 
     td->qtp.max_line_fit_mse = 10.0;
     td->qtp.cos_critical_rad = cos(10 * M_PI / 180);

--- a/apriltag_quad_thresh.c
+++ b/apriltag_quad_thresh.c
@@ -778,10 +778,6 @@ int fit_quad(
         bool reversed_border) {
     int res = 0;
 
-    int sz = zarray_size(cluster);
-    if (sz < 24) // Synchronize with later check.
-        return 0;
-
     /////////////////////////////////////////////////////////////
     // Step 1. Sort points so they wrap around the center of the
     // quad. We will constrain our quad fit to simply partition this
@@ -866,6 +862,7 @@ int fit_quad(
         ptsort((struct pt*) cluster->data, zarray_size(cluster));
     }
 
+    int sz = zarray_size(cluster);
     struct line_fit_pt *lfps = compute_lfps(sz, cluster, im);
 
     int indices[4];


### PR DESCRIPTION
Since fit_quad checks that the cluster size is above 24, the min_cluster_pixels comparision is essentially useless for values below 24. Invert it so that min_cluster_pixels is now 24, and remove the now redundant hardcoded 24 check. Move the size variable down as well for better locality of behavior.