### PR TITLE
Fix license in package.xml for SPDX conformance

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
   <maintainer email="Rauch.Christian@gmx.de">Christian Rauch</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-2-Clause</license>
   <url>https://april.eecs.umich.edu/software/apriltag.html</url>
 
   <author email="ebolson@umich.edu">Edwin Olson</author>


### PR DESCRIPTION
## Description

This PR updates the `<license>` tag in package.xml to `BSD-2-Clause`. It fixes building this package for Yocto after it started requiring SPDX license IDs.

## Motivation and Context

Required to build Yocto images with the apriltag package (tested with version 3.4.3).

## Related PRs

Yocto SDPX discussion in the meta-ros Yocto meta-layer:

* https://github.com/ros/meta-ros/issues/1208
* https://github.com/ros/meta-ros/issues/1216

## How has this been tested?

Before, Yocto builds fail when including the apriltag package with the error:

```
WARNING: apriltag-3.4.3-2-r0 do_populate_lic: QA Issue: apriltag: No generic license file exists for: BSD in any provider [license-exists]
ERROR: apriltag-3.4.3-2-r0 do_create_spdx: Cannot find any text for license BSD
```

When I manually update the license to `BSD-2-Clause` (and also apply https://github.com/ros/meta-ros/pull/1660), the Yocto build succeeds:

```patch
diff --git a/recipes-ros/apriltag/apriltag_%.bbappend b/recipes-ros/apriltag/apriltag_%.bbappend
new file mode 100644
index 0000000..ed4ad0c
--- /dev/null
+++ b/recipes-ros/apriltag/apriltag_%.bbappend
@@ -0,0 +1 @@
+LICENSE = "BSD-2-Clause"
```