### PR TITLE
Added MSVC utime_now implementation

### DIFF
--- a/common/time_util.h
+++ b/common/time_util.h
@@ -40,19 +40,7 @@ either expressed or implied, of the Regents of The University of Michigan.
 typedef long long suseconds_t;
 #endif
 
-#ifdef _MSC_VER
-
-inline int gettimeofday(struct timeval* tp, void* tzp)
-{
-  (void)tzp;
-
-  unsigned long t;
-  t = time(NULL);
-  tp->tv_sec = t / 1000;
-  tp->tv_usec = t % 1000;
-  return 0;
-}
-#else
+#ifndef _MSC_VER
 #include <sys/time.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
I have added an MSVC implementation for `utime_now` and removed the need to provide a `gettimeofday` as per the comments on #259.

I am using a combination of [`QueryPerfomanceCounter`](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter) to get the current `ticks` and [`QueryPerformanceFrequency`](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency) to allow me to convert those ticks into seconds (and then microseconds).

To avoid calling `QueryPerformanceFrequency` multiple times I have made use of [`InitOnceExecuteOnce`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initonceexecuteonce) to provide a thread safe way of making sure that the counter-frequency value is initialized before being used.

This builds and runs with Visual Studio Build Tools 2022 on Windows 11 (both 32 and 64 bit) and the demo exe gives output as follows ( with `-d` option to add a bit of variation to the times otherwise the run takes ~3ms)

```bash
.\apriltag_demo.exe -d images.jpg
loading images.jpg
image: images.jpg 273x185
detection   0: id (36x11)-0   , hamming 0, margin  236.577
 0                             init        0.001000 ms        0.001000 ms
 1                         decimate        0.066000 ms        0.067000 ms
 2                       blur/sharp        0.001000 ms        0.068000 ms
 3                        threshold        0.869000 ms        0.937000 ms
 4                        unionfind        4.305000 ms        5.242000 ms
 5                    make clusters        2.238000 ms        7.480000 ms
 6            fit quads to clusters       10.019000 ms       17.499000 ms
 7                            quads        0.155000 ms       17.654000 ms
 8                decode+refinement        6.538000 ms       24.192000 ms
 9                        reconcile        0.009000 ms       24.201000 ms
10                     debug output       62.874000 ms       87.075000 ms
11                          cleanup        0.018000 ms       87.093000 ms
hamm     1     0     0     0     0     0     0     0     0     0       87.092     9
Summary
hamm     1     0     0     0     0     0     0     0     0     0       87.092     9
```

Please let me know if there are any changes you would like to see.

Cheers

John