### PR TITLE
Remove sched_yield() from worker thread task pickup

### DIFF
--- a/common/workerpool.c
+++ b/common/workerpool.c
@@ -81,7 +81,6 @@ void *worker_thread(void *p)
         zarray_get_volatile(wp->tasks, wp->taskspos, &task);
         wp->taskspos++;
         pthread_mutex_unlock(&wp->mutex);
-        sched_yield();
 
         // we've been asked to exit.
         if (task->f == NULL)


### PR DESCRIPTION
Seems not needed and has a big performance impact, testing with hyperfine against `apriltag_demo -x 1.0 -t 4 -i 5 --family tagStandard52h13 --quiet <3 images.jpg>` it leads to a 1.2x speedup against master! It makes sense if you look at the code, why should the thread yield right as it's about to execute a task? 

Speedup is only on linux, on macOS it has no effect