### PR TITLE
Optimize unionfind cache locality.

### DIFF
--- a/common/unionfind.h
+++ b/common/unionfind.h
@@ -33,31 +33,37 @@ either expressed or implied, of the Regents of The University of Michigan.
 
 typedef struct unionfind unionfind_t;
 
+// Interleave node parent and size to improve cache locality.
+// Accessing parent[i] and size[i] hits the same cache line.
+struct unionfind_node
+{
+    // Parent node for each. Initialized to 0xffffffff
+    uint32_t parent;
+    // The size of the tree excluding the root
+    uint32_t size;
+};
+
 struct unionfind
 {
     uint32_t maxid;
-
-    // Parent node for each. Initialized to 0xffffffff
-    uint32_t *parent;
-
-    // The size of the tree excluding the root
-    uint32_t *size;
+    struct unionfind_node *data;
 };
 
 static inline unionfind_t *unionfind_create(uint32_t maxid)
 {
     unionfind_t *uf = (unionfind_t*) calloc(1, sizeof(unionfind_t));
     uf->maxid = maxid;
-    uf->parent = (uint32_t *) malloc((maxid+1) * sizeof(uint32_t) * 2);
-    memset(uf->parent, 0xff, (maxid+1) * sizeof(uint32_t));
-    uf->size = uf->parent + (maxid+1);
-    memset(uf->size, 0, (maxid+1) * sizeof(uint32_t));
+    uf->data = (struct unionfind_node *) malloc((maxid+1) * sizeof(struct unionfind_node));
+    for (uint32_t i = 0; i <= maxid; i++) {
+        uf->data[i].parent = 0xffffffff;
+        uf->data[i].size = 0;
+    }
     return uf;
 }
 
 static inline void unionfind_destroy(unionfind_t *uf)
 {
-    free(uf->parent);
+    free(uf->data);
     free(uf);
 }
 
@@ -83,16 +89,15 @@ static inline uint32_t unionfind_get_representative(unionfind_t *uf, uint32_t id
 static inline uint32_t unionfind_get_representative(unionfind_t *uf, uint32_t id)
 {
     // unititialized node, so set to self
-    if (uf->parent[id] == 0xffffffff) {
-        uf->parent[id] = id;
+    if (uf->data[id].parent == 0xffffffff) {
+        uf->data[id].parent = id;
         return id;
     }
 
     // Path halving: make every node point to its grandparent (single pass)
-    // This is simpler and faster than full path compression while still effective
-    while (uf->parent[id] != id) {
-        uf->parent[id] = uf->parent[uf->parent[id]];  // Point to grandparent
-        id = uf->parent[id];  // Move to grandparent
+    while (uf->data[id].parent != id) {
+        uf->data[id].parent = uf->data[uf->data[id].parent].parent;
+        id = uf->data[id].parent;
     }
 
     return id;
@@ -101,7 +106,7 @@ static inline uint32_t unionfind_get_representative(unionfind_t *uf, uint32_t id
 static inline uint32_t unionfind_get_set_size(unionfind_t *uf, uint32_t id)
 {
     uint32_t repid = unionfind_get_representative(uf, id);
-    return uf->size[repid] + 1;
+    return uf->data[repid].size + 1;
 }
 
 static inline uint32_t unionfind_connect(unionfind_t *uf, uint32_t aid, uint32_t bid)
@@ -119,8 +124,8 @@ static inline uint32_t unionfind_connect(unionfind_t *uf, uint32_t aid, uint32_t
     // for rank.  In my testing, it's often *faster* to use size than
     // rank, perhaps because the rank of the tree isn't that critical
     // if there are very few nodes in it.
-    uint32_t asize = uf->size[aroot] + 1;
-    uint32_t bsize = uf->size[broot] + 1;
+    uint32_t asize = uf->data[aroot].size + 1;
+    uint32_t bsize = uf->data[broot].size + 1;
 
     // optimization idea: We could shortcut some or all of the tree
     // that is grafted onto the other tree. Pro: those nodes were just
@@ -128,12 +133,12 @@ static inline uint32_t unionfind_connect(unionfind_t *uf, uint32_t aid, uint32_t
     // wasted effort -- the tree might be grafted onto another tree in
     // a moment!
     if (asize > bsize) {
-        uf->parent[broot] = aroot;
-        uf->size[aroot] += bsize;
+        uf->data[broot].parent = aroot;
+        uf->data[aroot].size += bsize;
         return aroot;
     } else {
-        uf->parent[aroot] = broot;
-        uf->size[broot] += asize;
+        uf->data[aroot].parent = broot;
+        uf->data[broot].size += asize;
         return broot;
     }
 }


### PR DESCRIPTION
This patch interleaves node parent and size to improve cache locality. With this, accessing parent[i] and size[i] hits the same cache line instead of arrays that are MBs apart. Note this change wouldn't make any difference on machines with MBs of cache, however on MCUs with a few KBs of cache, it shows a significant difference.

I've tested this on both real hardware (STMN6 Cortex-M55) and Arm's FVP (Fixed Virtual Platform) by running AprilTag on one of the test images 100 times and averaging run times. The results show ~5-6% speedup:

```bash
# N6/CM55
find_apriltags: 71473 us avg (100 runs)  # before
find_apriltags: 67636 us avg (100 runs) # after

# FVP/CM55
find_apriltags: 826046 us avg (100 runs)  # before
find_apriltags: 772852 us avg (100 runs)  # after
```