### PR TITLE
Fix include directory for in-tree usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ include(GNUInstallDirs)
 target_include_directories(${PROJECT_NAME} PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>/apriltag")
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/apriltag>")
 
 
 # install header file hierarchy


### PR DESCRIPTION
If apriltag is used as a submodule and used with `add_subdirectory` the include paths are now correct.