### PR TITLE
Add JavaScript/WebAssembly binding to third-party bindings list

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Provided by third-party [here](https://github.com/alddiaz/MATLAB_AprilTag3).
 
 Provided by third-party [here](https://github.com/JuliaRobotics/AprilTags.jl)
 
+### JavaScript / WebAssembly
+
+A browser-based port, compiled with Emscripten, provided by third-party
+[here](https://github.com/AliAlimohamad/apriltag-js). Runs entirely
+client-side with live camera or image-upload detection across all 8 tag
+families - no install, no server.
+
 
 ## Upgrading from AprilTag 2
 For most use-cases this should be a drop in replacement.


### PR DESCRIPTION
## Summary
Adds a `### JavaScript / WebAssembly` entry to the third-party bindings list in the README, following the existing format used for the Matlab and Julia entries.

The linked project (apriltag-js) is a WebAssembly port of this library that runs entirely in the browser - live camera or image-upload detection across all 8 tag families, no install or server component. All detection credit is attributed to this project in its own README.

## Test plan
- [x] Rendered README locally to confirm formatting matches the existing Matlab/Julia entries